### PR TITLE
Change the plugin vendor from KK to jenkins organization

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <name>Stapler Framework Support</name>
   <description>Assists with development of Java web applications using Stapler Framework (e.g. Jenkins plugins)</description>
-  <vendor url="https://jenkins.io/projects/stapler" email="jenkinsci-dev@googlegroups.com">jenkins</vendor>
+  <vendor url="https://github.com/jenkinsci/idea-stapler-plugin" email="jenkinsci-dev@googlegroups.com">jenkins</vendor>
   <category>Framework integration</category>
 <!--  Managed from build.gradle.kts -->
 <!--  <version>1.8</version>-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <name>Stapler Framework Support</name>
   <description>Assists with development of Java web applications using Stapler Framework (e.g. Jenkins plugins)</description>
-  <vendor>jenkins</vendor>
+  <vendor url="https://jenkins.io/projects/stapler" email="jenkinsci-dev@googlegroups.com">jenkins</vendor>
   <category>Framework integration</category>
 <!--  Managed from build.gradle.kts -->
 <!--  <version>1.8</version>-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <name>Stapler Framework Support</name>
   <description>Assists with development of Java web applications using Stapler Framework (e.g. Jenkins plugins)</description>
-  <vendor url="http://www.kohsuke.org/" email="kk@kohsuke.org">Kohsuke Kawaguchi</vendor>
+  <vendor>jenkins</vendor>
   <category>Framework integration</category>
 <!--  Managed from build.gradle.kts -->
 <!--  <version>1.8</version>-->


### PR DESCRIPTION
This should enable plugin transfer as per [Plugin transfer](https://plugins.jetbrains.com/docs/marketplace/organizations.html#plugin-transfer) doc.  Which then enable more contributors to upload new version. 