### PR TITLE
Restore the association bet *.jelly and XML language

### DIFF
--- a/src/main/java/org/kohsuke/stapler/idea/JellyFileTypeFactory.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyFileTypeFactory.java
@@ -1,13 +1,13 @@
 package org.kohsuke.stapler.idea;
 
-import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.fileTypes.FileTypeConsumer;
 import com.intellij.openapi.fileTypes.FileTypeFactory;
 import org.jetbrains.annotations.NotNull;
+import org.kohsuke.stapler.idea.jelly.JellyFileType;
 
 public class JellyFileTypeFactory extends FileTypeFactory {
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer consumer) {
-        consumer.consume(XmlFileType.INSTANCE, "jelly");
+        consumer.consume(JellyFileType.INSTANCE);
     }
 }

--- a/src/main/java/org/kohsuke/stapler/idea/jelly/JellyFileType.java
+++ b/src/main/java/org/kohsuke/stapler/idea/jelly/JellyFileType.java
@@ -1,0 +1,38 @@
+package org.kohsuke.stapler.idea.jelly;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.highlighter.XmlLikeFileType;
+import com.intellij.lang.xml.XMLLanguage;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class JellyFileType extends XmlLikeFileType {
+    public static final JellyFileType INSTANCE = new JellyFileType();
+
+    protected JellyFileType() {
+        super(XMLLanguage.INSTANCE);
+    }
+
+    @Override
+    public @NonNls @NotNull String getName() {
+        return "Jelly";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "Jelly";
+    }
+
+    @Override
+    public @NotNull String getDefaultExtension() {
+        return "jelly";
+    }
+
+    @Override
+    public @Nullable Icon getIcon() {
+        return AllIcons.FileTypes.Xml;
+    }
+}


### PR DESCRIPTION
Fix #58 by registering Jelly file type

Instead of adding an extension to an XML file type which appears to be not working on 2021.2 a new FileType is added which still maps to the XML language.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
