### PR TITLE
JEXL Inspection crashes are fixed by addressing logger initialization issue in JEXL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jenkins-ci:commons-jexl:1.1-jenkins-20111212'
+    implementation('org.jenkins-ci:commons-jexl:1.1-jenkins-20111212') {
+        // Provided by the Platform
+        exclude group: "commons-logging", module: "commons-logging"
+    }
     implementation 'net.java.dev.textile-j:textile-j:2.2.864'
 
     testImplementation 'junit:junit:4.13.2'

--- a/src/test/java/org/kohsuke/stapler/idea/JexlInspectionTest.java
+++ b/src/test/java/org/kohsuke/stapler/idea/JexlInspectionTest.java
@@ -35,4 +35,12 @@ public class JexlInspectionTest extends LightPlatformCodeInsightFixtureTestCase 
         List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING);
         assertEmpty(highlightInfos);
     }
+
+    public void testParserFailureJexlInspection() {
+        myFixture.configureByFile(getTestName(true) + ".jelly");
+        myFixture.enableInspections(new JexlInspection());
+        List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING);
+        assertNotEmpty(highlightInfos);
+        assertEquals("Two invalid JEXL expressions are used", 2, highlightInfos.size());
+    }
 }

--- a/src/test/testData/parserFailureJexlInspection.jelly
+++ b/src/test/testData/parserFailureJexlInspection.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core">
+    <!-- Got these from https://github.com/apache/commons-jexl/blob/c8af6a07df91d2a6d6d22adebf7c52ab02d2b74e/src/test/org/apache/commons/jexl/ParseFailuresTest.java -->
+    <j:if test="${?}">
+        ${eq}
+    </j:if>
+</j:jelly>


### PR DESCRIPTION
Use the commons-logging provided by the platform to avoid class initialization exception due to LogFactory inside the commons-jexl

Fixes #51

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

A test is added but it works just fine even without a fix. The classpath in the test must be different from the runtime making the problem not reproducible.