### PR TITLE
Deprecations are addressed to maintain compatibility with 2021.3 onward

### DIFF
--- a/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
@@ -68,7 +68,7 @@ public class JellyCompletionContributor extends CompletionContributor {
     public JellyCompletionContributor() {
         extend(CompletionType.BASIC, // in case of XML completion, this always seems to be BASIC
                 XML_ELEMENT_NAME_PATTERN,
-                new CompletionProvider<CompletionParameters>(true) {
+                new CompletionProvider<CompletionParameters>() {
                     // REFERENCE: spring plugin adds CompletionContributor as well.
                     @Override
                     protected void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext context, @NotNull CompletionResultSet result) {


### PR DESCRIPTION
* `CompletionProvider.<init>(boolean)` deprecation is addressed. It is removed in 2021.3. Even in 2016.2 it is just empty and doesn't use boolean parameter in any way, so safe to simply remove the argument.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
