### PR TITLE
`jellytag` extension is now supported since Stapler supports it for Tag Libraries. 

### DIFF
--- a/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
@@ -1,0 +1,35 @@
+package io.jenkins.stapler.idea.jelly;
+
+import com.intellij.internal.statistic.collectors.fus.fileTypes.FileTypeUsageSchemaDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+public class JellyFileTypeSchema implements FileTypeUsageSchemaDescriptor {
+    /**
+     * Default extension of the Apache Commons Jelly
+     */
+    public static final String JELLY_EXTENSION = "jelly";
+    /**
+     * Extension introduced by Stapler Framework to differentiate Jelly views from Tag Libraries that are made up of script files.
+     * For example:
+     * <a href="https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomTagLibrary.java#L128">CustomTagLibrary.java#L128</a>
+     * <a href="https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/ThisTagLibrary.java#L77">ThisTagLibrary.java#L77</a>
+     */
+    public static final String STAPLER_JELLY_TAG_EXTENSION = "jellytag";
+
+    @Override
+    public boolean describes(@NotNull Project project, @NotNull VirtualFile file) {
+        return isJelly(file);
+    }
+
+    public static boolean isJelly(@NotNull PsiFile file) {
+        return isJelly(file.getViewProvider().getVirtualFile());
+    }
+
+    public static boolean isJelly(@NotNull VirtualFile file) {
+        String fileExtension = file.getExtension();
+        return JELLY_EXTENSION.equals(fileExtension) || STAPLER_JELLY_TAG_EXTENSION.equals(fileExtension);
+    }
+}

--- a/src/main/java/org/kohsuke/stapler/idea/JellyAnnotator.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyAnnotator.java
@@ -10,6 +10,8 @@ import com.intellij.xml.XmlNSDescriptor;
 import com.intellij.xml.impl.schema.AnyXmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
 
+import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
+
 /**
  * Additional Jelly-specific {@link Annotator}.
  *
@@ -29,7 +31,7 @@ public class JellyAnnotator implements Annotator {
         if (psi instanceof XmlTag) {
             XmlTag tag = (XmlTag) psi;
 
-            if(!tag.getContainingFile().getName().endsWith(".jelly"))
+            if(!isJelly(tag.getContainingFile()))
                 return; // only do this in Jelly files
 
             // for elements

--- a/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
@@ -19,14 +19,14 @@ import com.intellij.psi.xml.XmlToken;
 import com.intellij.util.ProcessingContext;
 import com.intellij.xml.XmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
-import org.kohsuke.stapler.idea.descriptor.XmlNSDescriptorImpl;
+import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagLibraryXmlNSDescriptor;
 
 /**
  * Tag name completion for Jelly tag libraries defined as tag files.
  *
  * <p>
- * One would think that contributing {@link XmlNSDescriptorImpl} and
- * implementing {@link XmlNSDescriptorImpl#getRootElementsDescriptors(XmlDocument)} is enough
+ * One would think that contributing {@link StaplerCustomJellyTagLibraryXmlNSDescriptor} and
+ * implementing {@link StaplerCustomJellyTagLibraryXmlNSDescriptor#getRootElementsDescriptors(XmlDocument)} is enough
  * to cause the IDEA XML module to show tag name completions, but apparently it is not.
  *
  * <p>
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.idea.descriptor.XmlNSDescriptorImpl;
  * (they represent in-memory for-this-document-only temporary DTDs), and unless the body tag
  * appear elsewhere and have some children, it will return null from its
  * {@link XmlElementDescriptor#getElementDescriptor(XmlTag, XmlTag)} when given &lt;t:something/>,
- * and {@link TagNameReference}, which calls {@link XmlNSDescriptorImpl#getRootElementsDescriptors(XmlDocument)}
+ * and {@link TagNameReference}, which calls {@link StaplerCustomJellyTagLibraryXmlNSDescriptor#getRootElementsDescriptors(XmlDocument)}
  * to list up possible children, uses this as a signal that &lt;t:something/>
  * is not a valid child in this context.
  *
@@ -101,7 +101,7 @@ public class JellyCompletionContributor extends CompletionContributor {
                             String prefix = tag.getPrefixByNamespace(uri);
                             if(prefix!=null && prefix.length()>0)
                                 prefix+=':';
-                            XmlNSDescriptorImpl d = XmlNSDescriptorImpl.get(uri, module);
+                            StaplerCustomJellyTagLibraryXmlNSDescriptor d = StaplerCustomJellyTagLibraryXmlNSDescriptor.get(uri, module);
                             if(d!=null) {
                                 for( XmlElementDescriptor e : d.getRootElementsDescriptors(null/*I'm not using this parameter*/)) {
                                     //LookupItem item = LookupItem.fromString(prefix + e.getName());

--- a/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
@@ -21,6 +21,8 @@ import com.intellij.xml.XmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
 import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagLibraryXmlNSDescriptor;
 
+import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
+
 /**
  * Tag name completion for Jelly tag libraries defined as tag files.
  *
@@ -74,7 +76,7 @@ public class JellyCompletionContributor extends CompletionContributor {
                         XmlElement name = (XmlElement)parameters.getPosition();
 
                         // do this only inside Jelly files
-                        if(!name.getContainingFile().getName().endsWith(".jelly"))
+                        if(!isJelly(name.getContainingFile()))
                             return;
 
                         // this pseudo-tag represents the tag being completed.

--- a/src/main/java/org/kohsuke/stapler/idea/JellyDocumentationProvider.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyDocumentationProvider.java
@@ -8,8 +8,8 @@ import com.intellij.psi.xml.XmlTag;
 import com.intellij.xml.XmlAttributeDescriptor;
 import com.intellij.xml.XmlElementDescriptor;
 import org.jetbrains.annotations.Nullable;
-import org.kohsuke.stapler.idea.descriptor.XmlAttributeDescriptorImpl;
-import org.kohsuke.stapler.idea.descriptor.XmlElementDescriptorImpl;
+import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagfileXmlAttributeDescriptor;
+import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagfileXmlElementDescriptor;
 import org.kohsuke.stapler.idea.dom.model.DocumentationTag;
 
 /**
@@ -34,8 +34,8 @@ public class JellyDocumentationProvider extends AbstractDocumentationProvider {
         if (p instanceof XmlTag) {
             XmlTag t = (XmlTag) p;
             XmlElementDescriptor d = t.getDescriptor();
-            if (d instanceof XmlElementDescriptorImpl) {
-                XmlElementDescriptorImpl dd = (XmlElementDescriptorImpl) d;
+            if (d instanceof StaplerCustomJellyTagfileXmlElementDescriptor) {
+                StaplerCustomJellyTagfileXmlElementDescriptor dd = (StaplerCustomJellyTagfileXmlElementDescriptor) d;
                 DocumentationTag m = dd.getModel();
                 if(m==null)     return null;
                 return m.generateHtmlDoc();
@@ -44,8 +44,8 @@ public class JellyDocumentationProvider extends AbstractDocumentationProvider {
         if (p instanceof XmlAttribute) {
             XmlAttribute a = (XmlAttribute) p;
             XmlAttributeDescriptor ad = a.getDescriptor();
-            if (ad instanceof XmlAttributeDescriptorImpl) {
-                XmlAttributeDescriptorImpl o = (XmlAttributeDescriptorImpl) ad;
+            if (ad instanceof StaplerCustomJellyTagfileXmlAttributeDescriptor) {
+                StaplerCustomJellyTagfileXmlAttributeDescriptor o = (StaplerCustomJellyTagfileXmlAttributeDescriptor) ad;
                 return o.getModel().generateHtmlDoc();
             }
         } else {

--- a/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
@@ -17,6 +17,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
+
 /**
  * Injects CSS and JavaScript to suitable places
  *
@@ -25,7 +27,7 @@ import java.util.List;
 public class JellyLanguageInjector implements MultiHostInjector {
     @Override
     public void getLanguagesToInject(@NotNull final MultiHostRegistrar registrar, @NotNull PsiElement context) {
-        if(!context.getContainingFile().getName().endsWith(".jelly"))
+        if(!isJelly(context.getContainingFile()))
             return; // not a jelly file
 
         // inject CSS to @style

--- a/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
@@ -11,6 +11,8 @@ import com.intellij.psi.xml.XmlText;
 import org.apache.commons.jexl.ExpressionFactory;
 import org.apache.commons.jexl.parser.ParseException;
 
+import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
+
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -49,7 +51,7 @@ public class JexlInspection extends LocalXmlInspectionTool {
      * @param onTheFly
      */
     protected ProblemDescriptor[] check(XmlElement psi, InspectionManager manager, String text, TextRange range, boolean onTheFly) {
-        if(!psi.getContainingFile().getName().endsWith(".jelly"))
+        if(!isJelly(psi.getContainingFile()))
             return EMPTY_ARRAY; // not a jelly script
         if(!shouldCheck(psi))
             return EMPTY_ARRAY; // stapler not enabled

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/AnyElementDescriptorImpl.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/AnyElementDescriptorImpl.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Kohsuke Kawaguchi
  */
+// TODO: Is this even used?
 public class AnyElementDescriptorImpl implements XmlElementDescriptor {
     private final XmlTag tag;
 
@@ -39,7 +40,7 @@ public class AnyElementDescriptorImpl implements XmlElementDescriptor {
 
     @Override
     public XmlElementDescriptor getElementDescriptor(XmlTag childTag, XmlTag contextTag) {
-        XmlNSDescriptorImpl ns = XmlNSDescriptorImpl.get(childTag);
+        StaplerCustomJellyTagLibraryXmlNSDescriptor ns = StaplerCustomJellyTagLibraryXmlNSDescriptor.get(childTag);
         if(ns!=null)
             return ns.getElementDescriptor(childTag);
         return new AnyElementDescriptorImpl(childTag);

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/JellyTaglibMetadataContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/JellyTaglibMetadataContributor.java
@@ -13,12 +13,12 @@ public class JellyTaglibMetadataContributor implements MetaDataContributor {
     @Override
     public void contributeMetaData(MetaDataRegistrar registrar) {
         // this is so that we can create an XmlFile whose getRootElement().getMetaData()
-        // returns XmlNSDescriptorImpl. This is necessary to load schemas on the fly
+        // returns StaplerCustomJellyTagLibraryXmlNSDescriptor. This is necessary to load schemas on the fly
         registrar.registerMetaData(
                 new AndFilter(
                         new ClassFilter(XmlDocument.class),
                         new NamespaceFilter(DUMMY_SCHEMA_URL)),
-                XmlNSDescriptorImpl.class
+                StaplerCustomJellyTagLibraryXmlNSDescriptor.class
         );
     }
 }

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
@@ -27,9 +27,12 @@ import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
  * @author Kohsuke Kawaguchi
  */
 public class StaplerCustomJellyTagLibraryXmlNSDescriptor implements XmlNSDescriptorEx {
-    /**
-     * Stapler's <a href="https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomTagLibrary.java#L128-L130">CustomTagLibrary</a> supports standard Jelly Extension and also introduces its own tag extension.
-     * It is also extensible using {@code JellyTagFileLoader}-s, the only instance of which is <a href="https://github.com/jenkinsci/stapler/blob/2a13b906bf3af42bc610e4592d56eb8b511fa1be/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyTagFileLoader.java">GroovyTagFileLoader</a>
+    /*
+     * Stapler's `CustomTagLibrary`[1] introduces its own tag extension in addition to standard Jelly Extension.
+     * It is also extensible using `JellyTagFileLoader`-s, the only instance of which is `GroovyTagFileLoader`[2]
+     *
+     * 1: https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomTagLibrary.java#L128-L130
+     * 2: https://github.com/jenkinsci/stapler/blob/2a13b906bf3af42bc610e4592d56eb8b511fa1be/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyTagFileLoader.java
      */
     private static final List<String> DOT_TAGFILE_EXTENSIONS = List.of("." + STAPLER_JELLY_TAG_EXTENSION, "." + JELLY_EXTENSION, ".groovy");
     /**
@@ -129,7 +132,7 @@ public class StaplerCustomJellyTagLibraryXmlNSDescriptor implements XmlNSDescrip
     }
 
     /**
-     * This method is called when this object is instanciated by IDEA as metadata
+     * This method is called when this object is instantiated by IDEA as metadata
      * to existing object.
      * <p>
      * This special pseudo document has to be &lt;schema uri="..." xmlns="dummy-schema-url"/> 
@@ -162,8 +165,7 @@ public class StaplerCustomJellyTagLibraryXmlNSDescriptor implements XmlNSDescrip
         JavaPsiFacade javaPsi = JavaPsiFacade.getInstance(module.getProject());
 
         String pkgName = nsUri.substring(1).replace('/', '.');
-        // this invocation below successfully finds packages that includes
-        // invalid characters like 'a-b-c'
+        // this invocation below successfully finds packages that include invalid characters like 'a-b-c'
         PsiPackage pkg = javaPsi.findPackage(pkgName);
         if(pkg==null)   return null;
 

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class XmlNSDescriptorImpl implements XmlNSDescriptor {
+public class StaplerCustomJellyTagLibraryXmlNSDescriptor implements XmlNSDescriptor {
     /**
      * Namespace URI of a tag library.
      */
@@ -33,7 +33,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
      */
     private PsiDirectory dir;
 
-    public XmlNSDescriptorImpl(String uri, PsiDirectory dir) {
+    public StaplerCustomJellyTagLibraryXmlNSDescriptor(String uri, PsiDirectory dir) {
         this.uri = uri;
         this.dir = dir;
     }
@@ -43,7 +43,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
      *      Should be only invoked by IDEA.
      *      {@link #init(PsiElement)} call follows immediately.
      */
-    public XmlNSDescriptorImpl() {
+    public StaplerCustomJellyTagLibraryXmlNSDescriptor() {
     }
 
     public PsiDirectory getDir() {
@@ -54,7 +54,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
     public XmlElementDescriptor getElementDescriptor(@NotNull XmlTag tag) {
         PsiFile f = dir.findFile(tag.getLocalName() + ".jelly");
         if (f instanceof XmlFile)
-            return new XmlElementDescriptorImpl(this, (XmlFile)f);
+            return new StaplerCustomJellyTagfileXmlElementDescriptor(this, (XmlFile)f);
         return null;
     }
 
@@ -72,7 +72,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
         for(PsiFile f : dir.getFiles()) {
             if(!f.getName().endsWith(".jelly"))     continue;
             if (f instanceof XmlFile)
-                r.add(new XmlElementDescriptorImpl(this, (XmlFile)f));
+                r.add(new StaplerCustomJellyTagfileXmlElementDescriptor(this, (XmlFile)f));
         }
         return r.toArray(new XmlElementDescriptor[r.size()]);
     }
@@ -110,7 +110,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
     @Override
     public void init(PsiElement element) {
         XmlDocument doc = (XmlDocument) element;
-        dir = doc.getContainingFile().getUserData(XmlSchemaProviderImpl.MODULE);
+        dir = doc.getContainingFile().getUserData(StaplerCustomJellyTagLibraryXmlSchemaProvider.MODULE);
         uri = doc.getRootTag().getAttribute("uri","").getValue();
     }
 
@@ -119,7 +119,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
         return new Object[]{dir};
     }
 
-    public static XmlNSDescriptorImpl get(XmlTag tag) {
+    public static StaplerCustomJellyTagLibraryXmlNSDescriptor get(XmlTag tag) {
         if(!tag.getContainingFile().getName().endsWith(".jelly"))
             return null;    // this tag is not in a jelly script
 
@@ -127,7 +127,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
         return get(nsUri, ModuleUtil.findModuleForPsiElement(tag));
     }
 
-    public static XmlNSDescriptorImpl get(String nsUri, Module module) {
+    public static StaplerCustomJellyTagLibraryXmlNSDescriptor get(String nsUri, Module module) {
         // just trying to be defensive
         if(module==null) return null;
         if(nsUri.length()==0)   return null;
@@ -145,7 +145,7 @@ public class XmlNSDescriptorImpl implements XmlNSDescriptor {
         for (PsiDirectory dir : dirs)
             if(dir.findFile("taglib")!=null)
                 // this is a tag library
-                return new XmlNSDescriptorImpl(nsUri,dir);
+                return new StaplerCustomJellyTagLibraryXmlNSDescriptor(nsUri,dir);
 
         return null;
     }

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
@@ -19,10 +19,10 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author Kohsuke Kawaguchi
  */
-public class XmlSchemaProviderImpl extends XmlSchemaProvider {
+public class StaplerCustomJellyTagLibraryXmlSchemaProvider extends XmlSchemaProvider {
     @Override
     public XmlFile getSchema(@NotNull String url, @Nullable Module module, @NotNull PsiFile baseFile) {
-        XmlNSDescriptorImpl d = XmlNSDescriptorImpl.get(url, module);
+        StaplerCustomJellyTagLibraryXmlNSDescriptor d = StaplerCustomJellyTagLibraryXmlNSDescriptor.get(url, module);
         if(d==null)     return null;
 
         XmlFile pseudoSchema = (XmlFile) PsiFileFactory.getInstance(module.getProject()).createFileFromText(

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
@@ -12,6 +12,8 @@ import com.intellij.xml.XmlSchemaProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
+
 /**
  * This is not to be confused with W3C XML Schema. Rather,
  * it's a mechanism for locating a structure definition for a given URI
@@ -42,7 +44,7 @@ public class StaplerCustomJellyTagLibraryXmlSchemaProvider extends XmlSchemaProv
      */
     @Override
     public boolean isAvailable(@NotNull XmlFile file) {
-        return file.getName().endsWith(".jelly");
+        return isJelly(file);
     }
 
     /*package*/ static final Key<PsiDirectory> MODULE = Key.create(PsiDirectory.class.getName());

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagfileXmlAttributeDescriptor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagfileXmlAttributeDescriptor.java
@@ -11,17 +11,17 @@ import org.kohsuke.stapler.idea.dom.model.AttributeTag;
  *
  * @author Kohsuke Kawaguchi
 */
-public class XmlAttributeDescriptorImpl implements XmlAttributeDescriptor {
+public class StaplerCustomJellyTagfileXmlAttributeDescriptor implements XmlAttributeDescriptor {
     /**
      * Which element do we belong?
      */
-    private XmlElementDescriptorImpl element;
+    private StaplerCustomJellyTagfileXmlElementDescriptor element;
     /**
      * Definition of this attribute.
      */
     private final AttributeTag def;
 
-    XmlAttributeDescriptorImpl(XmlElementDescriptorImpl element, AttributeTag def) {
+    StaplerCustomJellyTagfileXmlAttributeDescriptor(StaplerCustomJellyTagfileXmlElementDescriptor element, AttributeTag def) {
         this.element = element;
         this.def = def;
     }

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagfileXmlElementDescriptor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagfileXmlElementDescriptor.java
@@ -22,18 +22,18 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class XmlElementDescriptorImpl extends BaseXmlElementDescriptorImpl {
-    private final XmlNSDescriptorImpl nsDescriptor;
+public class StaplerCustomJellyTagfileXmlElementDescriptor extends BaseXmlElementDescriptorImpl {
+    private final StaplerCustomJellyTagLibraryXmlNSDescriptor nsDescriptor;
     private final XmlFile tagFile;
 
-    public XmlElementDescriptorImpl(XmlNSDescriptorImpl nsDescriptor, XmlFile tagFile) {
+    public StaplerCustomJellyTagfileXmlElementDescriptor(StaplerCustomJellyTagLibraryXmlNSDescriptor nsDescriptor, XmlFile tagFile) {
         this.nsDescriptor = nsDescriptor;
         this.tagFile = tagFile;
     }
 
     @Override
     public XmlElementDescriptor getElementDescriptor(XmlTag child, XmlTag context) {
-        XmlNSDescriptorImpl ns = XmlNSDescriptorImpl.get(child);
+        StaplerCustomJellyTagLibraryXmlNSDescriptor ns = StaplerCustomJellyTagLibraryXmlNSDescriptor.get(child);
         if(ns==null) {
             {// here I'm trying to return a descriptor that allows anything/
                 /*
@@ -72,7 +72,7 @@ public class XmlElementDescriptorImpl extends BaseXmlElementDescriptorImpl {
         XmlAttributeDescriptor[] descriptors = new XmlAttributeDescriptor[atts.size()];
         int i=0;
         for (AttributeTag a : atts) {
-            descriptors[i++] = new XmlAttributeDescriptorImpl(this,a);
+            descriptors[i++] = new StaplerCustomJellyTagfileXmlAttributeDescriptor(this,a);
         }
         return descriptors;
     }

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/XmlElementDescriptorProviderImpl.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/XmlElementDescriptorProviderImpl.java
@@ -12,7 +12,7 @@ import com.intellij.xml.XmlElementDescriptor;
 public class XmlElementDescriptorProviderImpl implements XmlElementDescriptorProvider {
     @Override
     public XmlElementDescriptor getDescriptor(XmlTag tag) {
-        XmlNSDescriptorImpl ns = XmlNSDescriptorImpl.get(tag);
+        StaplerCustomJellyTagLibraryXmlNSDescriptor ns = StaplerCustomJellyTagLibraryXmlNSDescriptor.get(tag);
         if(ns!=null)    return ns.getElementDescriptor(tag);
         return null;
     }

--- a/src/main/java/org/kohsuke/stapler/idea/dom/model/AttributeTag.java
+++ b/src/main/java/org/kohsuke/stapler/idea/dom/model/AttributeTag.java
@@ -4,6 +4,8 @@ import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlTag;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 /**
  * {@link XmlTag} that wraps &lt;st:attribute>.
  *
@@ -20,13 +22,13 @@ public class AttributeTag extends TagWithHtmlContent {
      */
     @NotNull
     public String getName() {
-        XmlAttribute a = tag.getAttribute("name");
-        if(a==null)     return "";
-        return a.getValue();
+        return Optional.ofNullable(tag.getAttribute("name"))
+                .map(XmlAttribute::getValue)
+                .orElse("");
     }
 
     public boolean isRequired() {
-        XmlAttribute a = tag.getAttribute("use");
-        return a != null && a.getValue().equals("required");
+        Optional<String> mayBeUseAttrValue = Optional.ofNullable(tag.getAttribute("use")).map(XmlAttribute::getValue);
+        return mayBeUseAttrValue.isPresent() && mayBeUseAttrValue.get().equals("required");
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,11 @@
     <!-- Adds module Facet for Stapler -->
     <facetType implementation="org.kohsuke.stapler.idea.StaplerFacetType"/>
     <!-- Adds "*.jelly" to the XML file type extensions -->
-    <fileType name="XML" extensions="jelly" />
+    <!-- *.jellytag is a seldom used stapler jelly tag tag file extension
+         https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomTagLibrary.java#L128-L130 -->
+    <fileType name="XML" extensions="jelly;jellytag" />
+    <!-- Categorizes the Jelly files into separate category for JetBrains' stats. Also contains utilities for checking if a file is a Jelly file -->
+    <fileTypeUsageSchemaDescriptor schema="jelly" implementationClass="io.jenkins.stapler.idea.jelly.JellyFileTypeSchema" />
     <!-- ? -->
 <!--    <dom.fileDescription implementation="org.kohsuke.stapler.idea.dom.model.JellyDomDescription"/>-->
     <!-- Completion for Jelly Tags -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,7 +33,7 @@
                   extenderClass="org.kohsuke.stapler.idea.dom.model.JellyTagExtender"/>
     -->
     <!-- Dummy Schema for the Jelly Tag libraries -->
-    <xml.schemaProvider implementation="org.kohsuke.stapler.idea.descriptor.XmlSchemaProviderImpl" />
+    <xml.schemaProvider implementation="org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagLibraryXmlSchemaProvider" />
     <!-- Provide Metadata for Dummy Schemas -->
     <metaDataContributor implementation="org.kohsuke.stapler.idea.descriptor.JellyTaglibMetadataContributor" />
     <!-- ? -->


### PR DESCRIPTION
While investigating the StackOverflowError-s I noticed that XML metadata contributed by the plugins is specific for the [CustomTagLibrary](https://github.com/jenkinsci/stapler/blob/1709.ve4c10835694b_/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomTagLibrary.java) feature of Stapler. I decided to:

* Rename the classes appropriately to better align with stapler's codebase and hopefully improve readability
* Add the "jellytag" to the supported Jelly file extensions since it is expected by at least two tag library implementations: CustomTagLibrary and ThisTagLibrary. (It is barely used in real life, though).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
