### PR TITLE
Fix "IllegalArgumentException: Invalid range specified: (1, -1)" when editing `style` attribute in Jelly files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,14 @@ tasks.withType(JavaCompile) {
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
+// https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 
 // https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 // https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html
 // https://www.jetbrains.com/idea/download/other.html
 intellij {
     version = ideaVersion
+    type.set(ideaType)
     plugins = platformPlugins.tokenize(',')*.trim()
 }
 
@@ -103,7 +105,7 @@ runPluginVerifier {
     // Rather arbitrarily chosen first releases of last three year.
     // Product version in use statistics say last 3 major releases. It does not define "major release" though but
     // but educated guess is that `year.version` is what is considered major.
-    ideVersions = ["2020.3.2", "2021.3.3", "2022.1"]
+    ideVersions = ["2020.3.4", "2021.3.3", "2022.2.3"]
 }
 
 publishPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 # https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 # the first year based version (2016.2)
 ideaVersion=2020.3
+# see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension for list of accepted types
+ideaType=IC
 platformPlugins=properties,java
 intellijPublishToken=

--- a/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
@@ -44,11 +44,15 @@ public class JellyLanguageInjector implements MultiHostInjector {
             Language language = findLanguage("CSS");
             if (language == null) return;
 
-            registrar.startInjecting(language);
-            registrar.addPlace("dummy_selector {","}",
-                    (PsiLanguageInjectionHost)value,
-                    TextRange.from(1, value.getTextLength() - 2));
-            registrar.doneInjecting();
+            try {
+                registrar.startInjecting(language);
+                registrar.addPlace("dummy_selector {", "}",
+                                   (PsiLanguageInjectionHost) value,
+                                   TextRange.from(1, value.getTextLength() - 2));
+                registrar.doneInjecting();
+            } catch (IllegalArgumentException ignored) {
+                // occurs when syntax is malformed, like style==""
+            }
             return;
         }
         

--- a/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
@@ -42,17 +42,13 @@ public class JellyLanguageInjector implements MultiHostInjector {
                 return; // not a style attribute
 
             Language language = findLanguage("CSS");
-            if (language == null) return;
-
-            try {
-                registrar.startInjecting(language);
-                registrar.addPlace("dummy_selector {", "}",
-                                   (PsiLanguageInjectionHost) value,
-                                   TextRange.from(1, value.getTextLength() - 2));
-                registrar.doneInjecting();
-            } catch (IllegalArgumentException ignored) {
-                // occurs when syntax is malformed, like style==""
-            }
+            if (language == null || value.getTextLength() < 2) return;
+            
+            registrar.startInjecting(language);
+            registrar.addPlace("dummy_selector {", "}",
+                               (PsiLanguageInjectionHost) value,
+                               TextRange.from(1, value.getTextLength() - 2));
+            registrar.doneInjecting();
             return;
         }
         


### PR DESCRIPTION
Fixes #103 
Issue reproduced:

- use IDEA ultimate edition, which contains the CSS plugin (only for ultimate)
1. open any jelly file, and start typing:
<div style=
2. here, two double-quotes are added, CSS language is injected and auto-completion works between double-quotes
<div style=""
3. now, start typing an additional = next to to the previous =
<div style==""
=> error occurs

Changes:
- updated IDE versions (2022.2.3) in `build.gradle`
- added `type` attribute in `build.gradle` in order to be able to use ultimate edition during tests
- checked condition of `value.getTextLength()`

To test:
- `runIde -PideaVersion=<some version> -PideaType=IU` -> will run ultimate edition which contains CSS plugin
- reproduce steps, and see no exception, and completion works when syntax correctly fomed

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
