### PR TITLE
Avoid hardcoding releases to verify agains, by using JetBrains Gradle plugin feature that lists the releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ tasks.withType(JavaCompile) {
 // https://www.jetbrains.com/idea/download/other.html
 intellij {
     version = ideaVersion
-    type.set(ideaType)
+    type = ideaType
     plugins = platformPlugins.tokenize(',')*.trim()
 }
 
@@ -102,10 +102,12 @@ patchPluginXml {
 }
 
 runPluginVerifier {
-    // Rather arbitrarily chosen first releases of last three year.
-    // Product version in use statistics say last 3 major releases. It does not define "major release" though but
-    // but educated guess is that `year.version` is what is considered major.
-    ideVersions = ["2020.3.4", "2021.3.3", "2022.2.3"]
+//    jbrVersion = "8u202b1483.24"
+    subsystemsToCheck = "without-android"
+}
+
+listProductsReleases {
+    sinceVersion = "2020.1"
 }
 
 publishPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -102,12 +102,11 @@ patchPluginXml {
 }
 
 runPluginVerifier {
-//    jbrVersion = "8u202b1483.24"
     subsystemsToCheck = "without-android"
 }
 
 listProductsReleases {
-    sinceVersion = "2020.1"
+    sinceVersion = sinceIdeaVersion
 }
 
 publishPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ runPluginVerifier {
 }
 
 listProductsReleases {
-    sinceVersion = sinceIdeaVersion
+    sinceVersion = sinceIdeaVersion ?: ideaVersion
 }
 
 publishPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
-# https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
-# the first year based version (2016.2)
+# used for intellij build, see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-version 
 ideaVersion=2020.3
-# see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension for list of accepted types
+# specific property for runPluginVerifier 
+sinceIdeaVersion=2020.3
+# see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type for list of accepted types
 ideaType=IC
 platformPlugins=properties,java
 intellijPublishToken=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # used for intellij build, see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-version 
 ideaVersion=2020.3
-# specific property for runPluginVerifier 
-sinceIdeaVersion=2020.3
+# specific property for runPluginVerifier to override during runtime `-PsinceIdeaVersion=2022.1`
+sinceIdeaVersion=
 # see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type for list of accepted types
 ideaType=IC
 platformPlugins=properties,java

--- a/src/main/java/org/kohsuke/stapler/idea/icons/Icons.java
+++ b/src/main/java/org/kohsuke/stapler/idea/icons/Icons.java
@@ -8,5 +8,5 @@ import javax.swing.*;
  * @author Kohsuke Kawaguchi
  */
 public class Icons {
-    public static final Icon STAPLER = IconLoader.findIcon("/org/kohsuke/stapler/idea/icons/stapler.png");
+    public static final Icon STAPLER = IconLoader.getIcon("/org/kohsuke/stapler/idea/icons/stapler.png", Icons.class);
 }


### PR DESCRIPTION
Fixes #100 

Configuration of `runPluginVerifier` with list generated from `listProductsReleases` with `sinceVersion`.

Example of output when running `gradle runPluginVerifier -PideaVersion=2022.2.3` :

```
> Task :listProductsReleases
IC-2022.3
IC-2022.2.3
IC-2022.1.4
IC-2021.3.3
IC-2021.2.4
IC-2021.1.3
IC-2020.3.4
```

```
> Task :verifyPlugin
Download https://cache-redirector.jetbrains.com/download.jetbrains.com/idea/ideaIC-2021.3.3.tar.gz (32.73 MB / 802.97 MB)> Task :runPluginVerifier
Download https://cache-redirector.jetbrains.com/download.jetbrains.com/idea/ideaIC-2021.3.3.tar.gz, took 5 m 46 s 838 ms (802.97 MB)
Download https://cache-redirector.jetbrains.com/download.jetbrains.com/idea/ideaIC-2021.2.4.tar.gz, took 4 m 14 s 968 ms (839.65 MB)
Download https://cache-redirector.jetbrains.com/download.jetbrains.com/idea/ideaIC-2021.1.3.tar.gz, took 3 m 58 s 671 ms (817.03 MB)
Download https://cache-redirector.jetbrains.com/download.jetbrains.com/idea/ideaIC-2020.3.4.tar.gz, took 3 m 22 s 420 ms (734.53 MB)
Starting the IntelliJ Plugin Verifier 1.287
...
2022-10-11T00:50:18 [main] INFO  verification - Task check-plugin parameters:
Scheduled verifications (7):
Stapler plugin for IntelliJ IDEA:2.0.8 against IC-223.6160.11, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-222.4345.14, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-221.6008.13, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-213.7172.25, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-212.5712.43, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-211.7628.21, Stapler plugin for IntelliJ IDEA:2.0.8 against IC-203.8084.24

2022-10-11T00:50:19 [main] INFO  verification - Finished 1 of 7 verifications (in 0.6 s): IC-212.5712.43 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:19 [main] INFO  verification - Finished 2 of 7 verifications (in 1.1 s): IC-213.7172.25 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:20 [main] INFO  verification - Finished 3 of 7 verifications (in 1.2 s): IC-221.6008.13 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:20 [main] INFO  verification - Finished 4 of 7 verifications (in 1.2 s): IC-203.8084.24 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:20 [main] INFO  verification - Finished 5 of 7 verifications (in 1.2 s): IC-223.6160.11 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:20 [main] INFO  verification - Finished 6 of 7 verifications (in 1.2 s): IC-222.4345.14 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
2022-10-11T00:50:20 [main] INFO  verification - Finished 7 of 7 verifications (in 1.2 s): IC-211.7628.21 against Stapler plugin for IntelliJ IDEA:2.0.8: Compatible
Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-212.5712.43: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-213.7172.25: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-221.6008.13: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-203.8084.24: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-223.6160.11: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-222.4345.14: Compatible
    Plugin can be loaded/unloaded without IDE restart

Plugin Stapler plugin for IntelliJ IDEA:2.0.8 against IC-211.7628.21: Compatible
    Plugin can be loaded/unloaded without IDE restart

2022-10-11T00:50:20 [main] INFO  verification - Total time spent downloading plugins and their dependencies: 0 ms
2022-10-11T00:50:20 [main] INFO  verification - Total amount of plugins and dependencies downloaded: 0 B
2022-10-11T00:50:20 [main] INFO  verification - Total amount of space used for plugins and dependencies: 0 B
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
