### PR TITLE
Leverage new JellyFile type in more of the codebase

### DIFF
--- a/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
@@ -20,10 +20,6 @@ public class JellyFileTypeSchema implements FileTypeUsageSchemaDescriptor {
 
     @Override
     public boolean describes(@NotNull Project project, @NotNull VirtualFile file) {
-        return isJelly(file);
-    }
-
-    private static boolean isJelly(@NotNull VirtualFile file) {
         String fileExtension = file.getExtension();
         return JELLY_EXTENSION.equals(fileExtension) || STAPLER_JELLY_TAG_EXTENSION.equals(fileExtension);
     }

--- a/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/JellyFileTypeSchema.java
@@ -3,7 +3,6 @@ package io.jenkins.stapler.idea.jelly;
 import com.intellij.internal.statistic.collectors.fus.fileTypes.FileTypeUsageSchemaDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 
 public class JellyFileTypeSchema implements FileTypeUsageSchemaDescriptor {
@@ -24,11 +23,7 @@ public class JellyFileTypeSchema implements FileTypeUsageSchemaDescriptor {
         return isJelly(file);
     }
 
-    public static boolean isJelly(@NotNull PsiFile file) {
-        return isJelly(file.getViewProvider().getVirtualFile());
-    }
-
-    public static boolean isJelly(@NotNull VirtualFile file) {
+    private static boolean isJelly(@NotNull VirtualFile file) {
         String fileExtension = file.getExtension();
         return JELLY_EXTENSION.equals(fileExtension) || STAPLER_JELLY_TAG_EXTENSION.equals(fileExtension);
     }

--- a/src/main/java/org/kohsuke/stapler/idea/JellyAnnotator.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyAnnotator.java
@@ -10,7 +10,6 @@ import com.intellij.xml.XmlNSDescriptor;
 import com.intellij.xml.impl.schema.AnyXmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
 
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * Additional Jelly-specific {@link Annotator}.
@@ -30,10 +29,6 @@ public class JellyAnnotator implements Annotator {
     public void annotate(@NotNull PsiElement psi, @NotNull AnnotationHolder holder) {
         if (psi instanceof XmlTag) {
             XmlTag tag = (XmlTag) psi;
-
-            if(!isJelly(tag.getContainingFile()))
-                return; // only do this in Jelly files
-
             // for elements
             XmlNSDescriptor ns = tag.getDescriptor().getNSDescriptor();
             XmlElementDescriptor e = ns.getElementDescriptor(tag);

--- a/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
@@ -20,8 +20,8 @@ import com.intellij.util.ProcessingContext;
 import com.intellij.xml.XmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
 import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagLibraryXmlNSDescriptor;
+import org.kohsuke.stapler.idea.psi.JellyFile;
 
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * Tag name completion for Jelly tag libraries defined as tag files.
@@ -76,7 +76,7 @@ public class JellyCompletionContributor extends CompletionContributor {
                         XmlElement name = (XmlElement)parameters.getPosition();
 
                         // do this only inside Jelly files
-                        if(!isJelly(name.getContainingFile()))
+                        if(!(name.getContainingFile() instanceof JellyFile))
                             return;
 
                         // this pseudo-tag represents the tag being completed.

--- a/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyCompletionContributor.java
@@ -20,7 +20,6 @@ import com.intellij.util.ProcessingContext;
 import com.intellij.xml.XmlElementDescriptor;
 import org.jetbrains.annotations.NotNull;
 import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagLibraryXmlNSDescriptor;
-import org.kohsuke.stapler.idea.psi.JellyFile;
 
 
 /**
@@ -74,10 +73,6 @@ public class JellyCompletionContributor extends CompletionContributor {
                     @Override
                     protected void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet result) {
                         XmlElement name = (XmlElement)parameters.getPosition();
-
-                        // do this only inside Jelly files
-                        if(!(name.getContainingFile() instanceof JellyFile))
-                            return;
 
                         // this pseudo-tag represents the tag being completed.
                         XmlTag tag = (XmlTag) name.getParent();

--- a/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyLanguageInjector.java
@@ -13,11 +13,11 @@ import com.intellij.psi.xml.XmlElement;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.psi.xml.XmlText;
 import org.jetbrains.annotations.NotNull;
+import org.kohsuke.stapler.idea.psi.JellyFile;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * Injects CSS and JavaScript to suitable places
@@ -27,7 +27,7 @@ import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 public class JellyLanguageInjector implements MultiHostInjector {
     @Override
     public void getLanguagesToInject(@NotNull final MultiHostRegistrar registrar, @NotNull PsiElement context) {
-        if(!isJelly(context.getContainingFile()))
+        if(!(context.getContainingFile() instanceof JellyFile))
             return; // not a jelly file
 
         // inject CSS to @style

--- a/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
@@ -10,8 +10,8 @@ import com.intellij.psi.xml.XmlElement;
 import com.intellij.psi.xml.XmlText;
 import org.apache.commons.jexl.ExpressionFactory;
 import org.apache.commons.jexl.parser.ParseException;
+import org.kohsuke.stapler.idea.psi.JellyFile;
 
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -51,7 +51,7 @@ public class JexlInspection extends LocalXmlInspectionTool {
      * @param onTheFly
      */
     protected ProblemDescriptor[] check(XmlElement psi, InspectionManager manager, String text, TextRange range, boolean onTheFly) {
-        if(!isJelly(psi.getContainingFile()))
+        if(!(psi.getContainingFile() instanceof JellyFile))
             return EMPTY_ARRAY; // not a jelly script
         if(!shouldCheck(psi))
             return EMPTY_ARRAY; // stapler not enabled

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlNSDescriptor.java
@@ -15,13 +15,13 @@ import com.intellij.xml.XmlElementDescriptor;
 import com.intellij.xml.XmlNSDescriptorEx;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.kohsuke.stapler.idea.psi.JellyFile;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.JELLY_EXTENSION;
 import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.STAPLER_JELLY_TAG_EXTENSION;
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -150,7 +150,7 @@ public class StaplerCustomJellyTagLibraryXmlNSDescriptor implements XmlNSDescrip
     }
 
     public static StaplerCustomJellyTagLibraryXmlNSDescriptor get(XmlTag tag) {
-        if(!isJelly(tag.getContainingFile()))
+        if(!(tag.getContainingFile() instanceof JellyFile))
             return null;    // this tag is not in a jelly script
 
         String nsUri = tag.getNamespace();

--- a/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
+++ b/src/main/java/org/kohsuke/stapler/idea/descriptor/StaplerCustomJellyTagLibraryXmlSchemaProvider.java
@@ -11,8 +11,8 @@ import com.intellij.xml.XmlNSDescriptor;
 import com.intellij.xml.XmlSchemaProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.kohsuke.stapler.idea.psi.JellyFile;
 
-import static io.jenkins.stapler.idea.jelly.JellyFileTypeSchema.isJelly;
 
 /**
  * This is not to be confused with W3C XML Schema. Rather,
@@ -44,7 +44,7 @@ public class StaplerCustomJellyTagLibraryXmlSchemaProvider extends XmlSchemaProv
      */
     @Override
     public boolean isAvailable(@NotNull XmlFile file) {
-        return isJelly(file);
+        return file instanceof JellyFile;
     }
 
     /*package*/ static final Key<PsiDirectory> MODULE = Key.create(PsiDirectory.class.getName());


### PR DESCRIPTION
As discussed with @jgreffe . After his introduction of Jelly Language and file type, things could be simplified.

* `JellyFileTypeSchema` is left but the only public API now are constants that define Jelly extensions
* Where no longer necessary checks that the current file is Jelly are removed
* Where still necessary, instead of extension, a type of file object is checked instead.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~Link to relevant issues in GitHub or Jira~
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
