### PR TITLE
Revert "Bump org.jetbrains.intellij from 1.9.0 to 1.10.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.util.stream.Collectors
 
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.10.0'
+    id 'org.jetbrains.intellij' version '1.9.0'
 }
 
 group = "org.kohsuke.stapler.idea"


### PR DESCRIPTION
Reverts jenkinsci/idea-stapler-plugin#124

On Intel macOS 13.0.1 with 2020.3 as and IDEA version target the `buildPlugin` and `runIde` stopped working. They fork a process that prints a warning about `UseConcMarkSweepGC` and then `ClassNotFoundException` and exits with 1.

Reverting until baseline is updated.