### PR TITLE
i18n with single-quote exception Argument rangeInElement (9,25) endOffset must not exceed descriptor text range (38, 62) length (24)

### DIFF
--- a/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
@@ -1,5 +1,7 @@
 package org.kohsuke.stapler.idea;
 
+import java.util.Arrays;
+
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -71,7 +73,10 @@ public class JexlInspection extends LocalXmlInspectionTool {
 
         int endIndex = text.indexOf( "}", startIndex+2 );
 
-        if ( endIndex < 0 )
+        if ( endIndex < 0 ) {
+            additionalLog("Creating ProblemDescriptor",
+                          "file=" + psi.getContainingFile().getVirtualFile().getPath(),
+                          "text=" + text);
             return new ProblemDescriptor[] {
                 manager.createProblemDescriptor(psi,
                         new TextRange(startIndex, len),
@@ -80,6 +85,7 @@ public class JexlInspection extends LocalXmlInspectionTool {
                         onTheFly,
                         LocalQuickFix.EMPTY_ARRAY)
             };
+        }
 
         if ( startIndex == 0 && endIndex == len - 1 )
             return toArray(parseJexl(manager,psi,shrink(range,2,1),text.substring(2, endIndex),onTheFly));
@@ -340,6 +346,6 @@ public class JexlInspection extends LocalXmlInspectionTool {
     }
     
     private void additionalLog(String... details) {
-        LOG.warn(String.join("\n", details));
+        LOG.debugValues(details[0], Arrays.asList(details).subList(1, details.length));
     }
 }

--- a/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
@@ -1,8 +1,5 @@
 package org.kohsuke.stapler.idea;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;

--- a/src/test/java/org/kohsuke/stapler/idea/JexlInspectionTest.java
+++ b/src/test/java/org/kohsuke/stapler/idea/JexlInspectionTest.java
@@ -34,9 +34,12 @@ public class JexlInspectionTest extends BasePlatformTestCase {
         myFixture.enableInspections(new JexlInspection());
         List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING);
         assertNotEmpty(highlightInfos);
-        assertEquals("Expected error", 2, highlightInfos.size());
+        assertEquals("Expected error", 10, highlightInfos.size());
         assertEquals("Missing '}' character at the end of expression", highlightInfos.get(0).getDescription());
         assertTrue("Should match error", highlightInfos.get(1).getDescription().contains("Expecting \"(\" ..."));
+        for (int i = 2; i < 10; i++) {
+            assertEquals("Missing '}' character at the end of expression", highlightInfos.get(i).getDescription());
+        }
     }
 
     public void testTokenize() {

--- a/src/test/testData/i18nLookups.jelly
+++ b/src/test/testData/i18nLookups.jelly
@@ -3,4 +3,38 @@
     <p>${%Build Queue(items.size())}</p>
     <p>${%Failing</p>
     <p>${%Failing(items.size)}</p>
+    <p>
+        ${%Er'ror</p>
+    <p>
+        ${%Er\'ror</p>
+    <p>
+        ${%Er"ror</p>
+    <p>
+        ${%Er\"ror</p>
+    <p>
+        ${%Er'ror'</p>
+    <p>
+        ${%Er\'ror\'</p>
+    <p>
+        ${%Er"ror"</p>
+    <p>
+        ${%Er\"ror\"</p>
+    <p>${%Pas'ses}</p>
+    <p>${%Pas"ses}</p>
+    <p>
+        ${%Pas'ses}</p>
+    <p>
+        ${%Pas\'ses}</p>
+    <p>
+        ${%Pas"ses}</p>
+    <p>
+        ${%Pas\"ses}</p>
+    <p>
+        ${%Pas'ses'}</p>
+    <p>
+        ${%Pas\'ses\'}</p>
+    <p>
+        ${%Pas"ses"}</p>
+    <p>
+        ${%Pas\"ses\"}</p>
 </j:jelly>

--- a/src/test/testData/smokeJexlInspection.jelly
+++ b/src/test/testData/smokeJexlInspection.jelly
@@ -2,4 +2,8 @@
     <j:if test="${it.myBoolean}">
         ${it.myString}
     </j:if>
+    <j:set var="myVar" value="${something.split(&quot;#&quot;)}"/>
+    <j:if test="${minimum &gt; 0 &amp;&amp; minimum &lt; 2}">
+        ${it.something}
+    </j:if>
 </j:jelly>


### PR DESCRIPTION
Fixes #126 

- handle case of non-closed quotes
- unescape content before parsing

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
