### PR TITLE
Add 'since' attribute to the 'attribute' tag of the Stapler tag library

### DIFF
--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
@@ -424,6 +424,11 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
+      <xsd:attribute name="since">
+        <xsd:annotation>
+          <xsd:documentation>Used to track when the attribute was added to the API surface.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>


### PR DESCRIPTION
The tag does already exist, see https://github.com/jenkinsci/stapler/blob/cea4497990e88143e543410ea0817c15b3e86d1a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeTag.java#L75-L79, yet remained undocumented.
This PR takes care of that.