### PR TITLE
Document 'out' tag

### DIFF
--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
@@ -1310,7 +1310,11 @@
   </xsd:element>
   <xsd:element name="out">
     <xsd:annotation>
-      <xsd:documentation>Cancels the effect of &lt;?jelly escape-by-default='true'?&gt; and allow expressions to produce mark up.</xsd:documentation>
+      <xsd:documentation>Cancels the effect of &lt;?jelly escape-by-default='true'?&gt; and allow expressions to produce mark up.
+        <tagtag>out</tagtag>
+        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
+        <versiontag>$Revision: 847 $</versiontag>
+      </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -1318,7 +1322,9 @@
       </xsd:sequence>
       <xsd:attribute name="value">
         <xsd:annotation>
-          <xsd:documentation>The value that should be escaped.</xsd:documentation>
+          <xsd:documentation>The value that should be escaped.
+            <requiredtag>true</requiredtag>
+          </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
@@ -1308,4 +1308,19 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="out">
+    <xsd:annotation>
+      <xsd:documentation>Cancels the effect of &lt;?jelly escape-by-default='true'?&gt; and allow expressions to produce mark up.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>The value that should be escaped.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>


### PR DESCRIPTION
The documentation itself is taken from https://wiki.jenkins.io/display/JENKINS/Jelly+and+XSS+prevention

The wiki is quite dated, yet this tag is used still: https://github.com/search?q=org%3Ajenkinsci+%22%3Aout%22+lang%3Axml&type=code