### PR TITLE
Update Jelly Tag Library XSDs

### DIFF
--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/ant.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/ant.xsd
@@ -1,16 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:ant" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:ant" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
+
       <p>A tag library for using Ant tasks within Jelly</p>
-      <p>Jelly can be invoked inside Ant and this tag library allows Ant tasks to be invoked from insideJelly. This allows Jelly to be used for more 'scripting' style targets, such as parsing XML databases,working with custom java beans, doing SQL, the use of JSTL and so forth.</p>
+
+
+
+      <p>Jelly can be invoked inside Ant and this tag library allows Ant tasks to be invoked from inside
+        Jelly. This allows Jelly to be used for more 'scripting' style targets, such as parsing XML databases,
+        working with custom java beans, doing SQL, the use of JSTL and so forth.
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
+
   <xsd:element name="setProperty">
     <xsd:annotation>
-      <xsd:documentation>Tag which sets an attribute on the parent Ant Task if the given value is not null.This can be useful when setting parameters on Ant tasks, only if they have been specifiedvia some well defined property, otherwise allowing the inbuilt default to be used.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-      </xsd:documentation>
+      <xsd:documentation>Tag which sets an attribute on the parent Ant Task if the given value is not null.
+        This can be useful when setting parameters on Ant tasks, only if they have been specified
+        via some well defined property, otherwise allowing the inbuilt default to be used.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -18,16 +27,12 @@
       </xsd:sequence>
       <xsd:attribute name="name">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of the Ant task property to set.
-          <paramtag>name The name of the Ant task property to set</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the name of the Ant task property to set.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="value">
         <xsd:annotation>
-          <xsd:documentation>Sets the value of the Ant task property to set.
-          <paramtag>value The value of the Ant task property to set</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the value of the Ant task property to set.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="default">
@@ -40,11 +45,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -52,12 +52,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="fileScanner">
     <xsd:annotation>
-      <xsd:documentation>A tag which creates a new FileScanner bean instance that can be used toiterate over fileSets
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which creates a new FileScanner bean instance that can be used to
+        iterate over fileSets</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -73,11 +72,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -85,12 +79,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="ant">
     <xsd:annotation>
-      <xsd:documentation>Tag supporting ant's Tasks as well asdynamic runtime behaviour for 'unknown' tags.
-        <authortag>&lt;a href="mailto:bob@eng.werken.com"&gt;bob mcwhirter&lt;/a&gt;</authortag>
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-      </xsd:documentation>
+      <xsd:documentation>Tag supporting ant's Tasks as well as
+        dynamic runtime behaviour for 'unknown' tags.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -98,17 +91,10 @@
       </xsd:sequence>
       <xsd:attribute name="object">
         <xsd:annotation>
-          <xsd:documentation>Set the object underlying this tag.
-          <paramtag>object The object.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Set the object underlying this tag.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -120,4 +106,5 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
@@ -1108,6 +1108,33 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="out">
+    <xsd:annotation>
+      <xsd:documentation>A tag which evaluates an expression</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Jexl expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="invokeStatic">
     <xsd:annotation>
       <xsd:documentation>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
@@ -1,16 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:core" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:core" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>The core Tags from the JSTL plus Jelly extensions.</p>
+
+      <p>The core Tags from the JSTL plus Jelly extensions.
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="jelly">
+
+  <xsd:element name="whitespace">
     <xsd:annotation>
-      <xsd:documentation>The root Jelly tag which should be evaluated first
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A simple tag used to preserve whitespace inside its body</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -18,27 +19,22 @@
       </xsd:sequence>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="break">
+
+  <xsd:element name="while">
     <xsd:annotation>
-      <xsd:documentation>A tag which terminates the execution of the current &lt;forEach&gt;or &amp;lg;while&gt;loop. This tag can take an optional boolean test attribute which if its truethen the break occurs otherwise the loop continues processing.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which performs an iteration while the result of an expression is true.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -46,43 +42,204 @@
       </xsd:sequence>
       <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the Jelly expression to evaluate (optional).If this is
-          <code>null</code>or evaluates to
-          <code>true</code>then the loop is terminated
-          <paramtag>test the Jelly expression to evaluate</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to export indicating if the item was broken
-          <paramtag>var name of the variable to be exported</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for the expression</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="when">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="test">
+        <xsd:annotation>
+          <xsd:documentation>Sets the expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="useList">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a List implementation and optionally
+        adds all of the elements identified by the items attribute.
+        The exact implementation of List can be specified via the
+        class attribute</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ignoreUnknownProperties">
+        <xsd:annotation>
+          <xsd:documentation>If this tag finds an attribute in the XML that's not
+            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
+            bean property, should it throw an exception?</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="useBean">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which instantiates an instance of the given class
+        and then sets the properties on the bean.
+        The class can be specified via a java.lang.Class instance or
+        a String which will be used to load the class using either the current
+        thread's context class loader or the class loader used to load this
+        Jelly library.
+
+        This tag can be used it as follows,
+
+
+        <pre>
+          &lt;j:useBean var="person" class="com.acme.Person" name="James" location="${loc}"/&gt;
+          &lt;j:useBean var="order" class="${orderClass}" amount="12" price="123.456"/&gt;
+        </pre>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ignoreUnknownProperties">
+        <xsd:annotation>
+          <xsd:documentation>If this tag finds an attribute in the XML that's not
+            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
+            bean property, should it throw an exception?</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="thread">
+    <xsd:annotation>
+      <xsd:documentation>A tag that spawns the contained script in a separate thread</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the thread.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="xmlOutput">
+        <xsd:annotation>
+          <xsd:documentation>Sets the destination of output</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Set the file which is generated from the output</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="switch">
+    <xsd:annotation>
+      <xsd:documentation>Executes the child &lt;case&gt; tag whose value equals my on attribute.
+        Executes a child &lt;default&gt; tag when present and no &lt;case&gt; tag has
+        yet matched.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="on">
+        <xsd:annotation>
+          <xsd:documentation>Sets the value to switch on.
+            Note that the org.apache.commons.jelly.expression.Expression is evaluated only once, when the
+            &lt;switch&gt; tag is evaluated.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="set">
     <xsd:annotation>
-      <xsd:documentation>A tag which sets a variable from the result of an expression
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which sets a variable from the result of an expression</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -95,7 +252,11 @@
       </xsd:attribute>
       <xsd:attribute name="scope">
         <xsd:annotation>
-          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' willset this value in the parent scope. When Jelly is run from inside a Servlet environmentthen other scopes will be available such as 'request', 'session' or 'application'.Other applications may implement their own custom scopes.</xsd:documentation>
+          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' will
+            set this value in the parent scope. When Jelly is run from inside a Servlet environment
+            then other scopes will be available such as 'request', 'session' or 'application'.
+
+            Other applications may implement their own custom scopes.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="value">
@@ -105,7 +266,8 @@
       </xsd:attribute>
       <xsd:attribute name="defaultValue">
         <xsd:annotation>
-          <xsd:documentation>Sets the default value to be used if the value exprsesion resultsin a null value or blank String</xsd:documentation>
+          <xsd:documentation>Sets the default value to be used if the value exprsesion results
+            in a null value or blank String</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="target">
@@ -120,32 +282,299 @@
       </xsd:attribute>
       <xsd:attribute name="encode">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be XML encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.This is only used if this tag is specified with no value so that the text body of thistag is used as the body.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be XML encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.
+            This is only used if this tag is specified with no value so that the text body of this
+            tag is used as the body.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="setProperties">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which sets the bean properties on the given bean.
+        So if you used it as follows, for example using the &lt;j:new&gt; tag.
+
+
+        <pre>
+          &lt;j:new className="com.acme.Person" var="person"/&gt;
+          &lt;j:setProperties object="${person}" name="James" location="${loc}"/&gt;
+        </pre>
+        Then it would set the name and location properties on the bean denoted by
+        the expression ${person}.
+
+
+        <p>
+          This tag can also be nested inside a bean tag such as the &lt;useBean&gt; tag
+          or a JellySwing tag to set one or more properties, maybe inside some conditional
+          logic.</p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="scope">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a new child variable scope for its body.
+        So any variables defined within its body will no longer be in scope
+        after this tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="remove">
+    <xsd:annotation>
+      <xsd:documentation>A tag which removes the variable of the given name from the current variable scope.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which will be removed by this tag..</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="parse">
+    <xsd:annotation>
+      <xsd:documentation>Parses the output of this tags body or of a given String as a Jelly script
+        then either outputting the Script as a variable or executing the script.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="XMLReader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XMLReader used for parsing</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="jellyParser">
+        <xsd:annotation>
+          <xsd:documentation>Sets the jellyParser.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="otherwise">
+    <xsd:annotation>
+      <xsd:documentation>The otherwise block of a choose/when/otherwise group of tags</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="new">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a new object of the given type</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the class name of the object to instantiate</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Set the class loader to be used for instantiating application objects
+            when required.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="useContextClassLoader">
+        <xsd:annotation>
+          <xsd:documentation>
+            Determine whether to use the Context ClassLoader (the one found by
+            calling
+
+            <code>Thread.currentThread().getContextClassLoader()</code>
+            )
+            to resolve/load classes.  If not
+            using Context ClassLoader, then the class-loading defaults to
+            using the calling-class' ClassLoader.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="mute">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which executes its body but passing no output.
+
+
+        <p>
+          Using this tag will still take the time to perform toString on each object
+          returned to the output (but this toString value is discarded.
+          A future version should go more internally so that this is avoided.</p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="jelly">
+    <xsd:annotation>
+      <xsd:documentation>The root Jelly tag which should be evaluated first</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="invoke">
     <xsd:annotation>
-      <xsd:documentation>A tag which calls a method in an object instantied by core:new
-        <authortag>Rodney Waldhoff</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which calls a method in an object instantied by core:new</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -158,7 +587,8 @@
       </xsd:attribute>
       <xsd:attribute name="exceptionVar">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of a variable that exports the exception thrown bythe method's invocation (if any)</xsd:documentation>
+          <xsd:documentation>Sets the name of a variable that exports the exception thrown by
+            the method's invocation (if any)</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="method">
@@ -173,60 +603,99 @@
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="when">
+
+  <xsd:element name="invokeStatic">
     <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
+      <xsd:documentation>
+        A Tag which can invoke a static method on a class, without an
+        instance of the class being needed.
+
+
+        <p>
+          Like the </p>
+        org.apache.commons.jelly.tags.core.InvokeTag, this tag can take a set of
+        arguments using the org.apache.commons.jelly.tags.core.ArgTag.
+
+
+        <p/>
+
+
+        <p>
+          The following attributes are required:
+
+
+          <ul>
+
+
+            <li>var - The variable to assign the return of the method call to</li>
+
+
+            <li>method - The name of the static method to invoke</li>
+
+
+            <li>className - The name of the class containing the static method</li>
+
+          </ul>
+
+        </p>
+
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="test">
+      <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the expression to evaluate.</xsd:documentation>
+          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="exceptionVar">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of a variable that exports the exception thrown by
+            the method's invocation (if any)</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="method">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the method to invoke</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the fully qualified class name containing the static method</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="include">
     <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -244,7 +713,8 @@
       </xsd:attribute>
       <xsd:attribute name="file">
         <xsd:annotation>
-          <xsd:documentation>Sets the file to be included which is either an absolute file or a filerelative to the current directory</xsd:documentation>
+          <xsd:documentation>Sets the file to be included which is either an absolute file or a file
+            relative to the current directory</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="uri">
@@ -254,26 +724,268 @@
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="import">
+    <xsd:annotation>
+      <xsd:documentation>
+        Imports another script.
+
+
+
+        <p>
+          By default, the imported script does not have access to
+          the parent script's variable context.  This behaviour
+          may be modified using the
+
+          <code>inherit</code>
+          attribute.
+
+        </p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="inherit">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether property inheritence is enabled or disabled</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the URI (relative URI or absolute URL) for the script to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file for the script to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="if">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="test">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Jelly expression to evaluate. If this returns true, the body of
+            the tag is evaluated</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="getStatic">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which can retrieve the value of a static field of a given class.
+        The following attributes are required:
+
+
+        <ul>
+
+
+          <li>var - The variable to which to assign the resulting value.</li>
+
+
+          <li>field - The name of the static field to retrieve.</li>
+
+
+          <li>className - The name of the class containing the static field.</li>
+
+        </ul>
+        Example usage:
+
+
+        <pre>
+          &lt;j:getStatic var="closeOperation" className="javax.swing.JFrame"
+          field="EXIT_ON_CLOSE"/&gt;
+        </pre>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable exported by this tag.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="field">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the field to retrieve.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the fully qualified name of the class containing the static field.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="forEach">
+    <xsd:annotation>
+      <xsd:documentation>
+        Iterates over a collection, iterator or an array of objects.
+        Uses the same syntax as the
+
+        <a>JSTL</a>
+
+
+        <code>forEach</code>
+        tag does.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="items">
+        <xsd:annotation>
+          <xsd:documentation>Sets the expression used to iterate over.
+            This expression could resolve to an Iterator, Collection, Map, Array,
+            Enumeration or comma separated String.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name to export for the item being iterated over</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="indexVar">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name to export the current index counter to</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="begin">
+        <xsd:annotation>
+          <xsd:documentation>Sets the starting index value</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="end">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ending index value</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="step">
+        <xsd:annotation>
+          <xsd:documentation>Sets the index increment step</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varStatus">
+        <xsd:annotation>
+          <xsd:documentation>
+            Sets the variable name to export the current status to.
+            The status is an implementation of the JSTL LoopTagStatus interface that provides
+            the following bean properties:
+
+
+            <ul>
+
+
+              <li>current - the current value of the loop items being iterated</li>
+
+
+              <li>index   - the current index of the items being iterated</li>
+
+
+              <li>first   - true if this is the first iteration, false otherwise</li>
+
+
+              <li>last    - true if this is the last iteration, false otherwise</li>
+
+
+              <li>begin   - the starting index of the loop</li>
+
+
+              <li>step    - the stepping value of the loop</li>
+
+
+              <li>end     - the end index of the loop</li>
+
+            </ul>
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="file">
     <xsd:annotation>
-      <xsd:documentation>A tag that pipes its body to a file denoted by the name attribute or to an in memory Stringwhich is then output to a variable denoted by the var variable.
-        <authortag>&lt;a href="mailto:vinayc@apache.org"&gt;Vinay Chandran&lt;/a&gt;</authortag>
-      </xsd:documentation>
+      <xsd:documentation>A tag that pipes its body to a file denoted by the name attribute or to an in memory String
+        which is then output to a variable denoted by the var variable.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -306,39 +1018,94 @@
       </xsd:attribute>
       <xsd:attribute name="append">
         <xsd:annotation>
-          <xsd:documentation>Sets wether to append at the end of the file(not really something you normally do with an XML file).</xsd:documentation>
+          <xsd:documentation>Sets wether to append at the end of the file
+            (not really something you normally do with an XML file).</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the var.
-          <paramtag>var The var to set</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the var.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="expr">
+    <xsd:annotation>
+      <xsd:documentation>A tag which evaluates an expression</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Jexl expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="default">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body if
+        none of its preceeding sibling &lt;case&gt;
+        tags have been evaluated.
+
+        This tag must be contained within the body of some
+        &lt;switch&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="fallThru">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="choose">
     <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -346,28 +1113,95 @@
       </xsd:sequence>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="while">
+
+  <xsd:element name="catch">
     <xsd:annotation>
-      <xsd:documentation>A tag which performs an iteration while the result of an expression is true.
-        <authortag>&lt;a href="mailto:eric@ericalexander.net"&gt;Eric Alexander&lt;/a&gt;</authortag>
-        <authortag>dIon Gillard</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which catches exceptions thrown by its body.
+        This allows conditional logic to be performed based on if exceptions
+        are thrown or to do some kind of custom exception logging logic.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which is exposed with the Exception that gets
+            thrown by evaluating the body of this tag or which is set to null if there is
+            no exception thrown.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="case">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body if
+        my value attribute equals my ancestor
+        &lt;switch&gt; tag's
+        "on" attribute.
+
+        This tag must be contained within the body of some
+        &lt;switch&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="fallThru">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="break">
+    <xsd:annotation>
+      <xsd:documentation>A tag which terminates the execution of the current &lt;forEach&gt; or &lt;while&gt;
+        loop. This tag can take an optional boolean test attribute which if its true
+        then the break occurs otherwise the loop continues processing.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -375,176 +1209,52 @@
       </xsd:sequence>
       <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Setter for the expression
-          <paramtag>e the expression to test</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>
+            Sets the Jelly expression to evaluate (optional).
+            If this is
+
+            <code>null</code>
+            or evaluates to
+
+
+            <code>true</code>
+            then the loop is terminated
+          </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="useList">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a List implementation and optionallyadds all of the elements identified by the items attribute.The exact implementation of List can be specified via theclass attribute
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="ignoreUnknownProperties">
-        <xsd:annotation>
-          <xsd:documentation>If this tag finds an attribute in the XML that's notignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignorePropertiesand isn't abean property, should it throw an exception?
-          <paramtag>ignoreUnknownProperties Sets {@link #ignoreUnknownProperties}.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="getStatic">
-    <xsd:annotation>
-      <xsd:documentation>A tag which can retrieve the value of a static field of a given class.The following attributes are required:
-        <br/>
-        <ul><li>var - The variable to which to assign the resulting value.</li><li>field - The name of the static field to retrieve.</li><li>className - The name of the class containing the static field.</li></ul>Example usage:
-        <pre> &lt;j:getStatic var="closeOperation" className="javax.swing.JFrame"field="EXIT_ON_CLOSE"/&gt;</pre>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
       <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable exported by this tag.
-          <paramtag>var The variable name.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="field">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the field to retrieve.
-          <paramtag>method The method name</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the fully qualified name of the class containing the static field.
-          <paramtag>className The name of the class.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the variable name to export indicating if the item was broken</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="scope">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a new child variable scope for its body.So any variables defined within its body will no longer be in scopeafter this tag.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
+
+  <xsd:element name="">
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="whitespace">
-    <xsd:annotation>
-      <xsd:documentation>A simple tag used to preserve whitespace inside its body
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="arg">
     <xsd:annotation>
-      <xsd:documentation>An argument to a org.apache.commons.jelly.tags.core.NewTagor org.apache.commons.jelly.tags.core.InvokeTag.This tag MUST be enclosed within an org.apache.commons.jelly.tags.core.ArgTagParentimplementation.
-        <authortag>Rodney Waldhoff</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>An argument to a org.apache.commons.jelly.tags.core.NewTag or org.apache.commons.jelly.tags.core.InvokeTag.
+        This tag MUST be enclosed within an org.apache.commons.jelly.tags.core.ArgTagParent
+        implementation.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -552,14 +1262,21 @@
       </xsd:sequence>
       <xsd:attribute name="type">
         <xsd:annotation>
-          <xsd:documentation>The name of the argument class or type, if any.This may be a fully specified class name ora primitive type name(
-          <code>boolean
-            <code>,
-              <code>int</code>,
-              <code>double</code>, etc.).
-            </code>
-          </code>
-        </xsd:documentation>
+          <xsd:documentation>
+            The name of the argument class or type, if any.
+            This may be a fully specified class name or
+            a primitive type name
+            (
+
+            <code>boolean</code>
+            ,
+
+            <code>int</code>
+            ,
+
+            <code>double</code>
+            , etc.).
+          </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="value">
@@ -569,743 +1286,37 @@
       </xsd:attribute>
       <xsd:attribute name="classLoader">
         <xsd:annotation>
-          <xsd:documentation>Set the class loader to be used for instantiating application objectswhen required.
-          <paramtag>classLoader The new class loader to use, or &lt;code&gt;null&lt;/code&gt; to revert to the standard rules</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Set the class loader to be used for instantiating application objects
+            when required.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="useContextClassLoader">
         <xsd:annotation>
-          <xsd:documentation>Determine whether to use the Context ClassLoader (the one found bycalling
-          <code>Thread.currentThread().getContextClassLoader()</code>)to resolve/load classes. If notusing Context ClassLoader, then the class-loading defaults tousing the calling-class' ClassLoader.
-          <paramtag>boolean determines whether to use JellyContext ClassLoader.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="switch">
-    <xsd:annotation>
-      <xsd:documentation>Executes the child &lt;case&gt;tag whose value equals my on attribute.Executes a child &lt;default&gt;tag when present and no &lt;case&gt;tag hasyet matched.
-        <seetag>CaseTag</seetag>
-        <seetag>DefaultTag</seetag>
-        <authortag>Rodney Waldhoff</authortag>
-        <versiontag>$Revision: 847 $ $Date: 2009-01-05 20:57:19 -0800 (Mon, 05 Jan 2009) $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="on">
-        <xsd:annotation>
-          <xsd:documentation>Sets the value to switch on.Note that the org.apache.commons.jelly.expression.Expressionis evaluated only once, when the &lt;switch&gt;tag is evaluated.
-          <paramtag>on the value to switch on</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="useBean">
-    <xsd:annotation>
-      <xsd:documentation>A tag which instantiates an instance of the given classand then sets the properties on the bean.The class can be specified via a java.lang.Classinstance ora String which will be used to load the class using either the currentthread's context class loader or the class loader used to load thisJelly library.This tag can be used it as follows,
-        <pre> &lt;j:useBean var="person" class="com.acme.Person" name="James" location="${loc}"/&gt; &lt;j:useBean var="order" class="${orderClass}" amount="12" price="123.456"/&gt;</pre>
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="ignoreUnknownProperties">
-        <xsd:annotation>
-          <xsd:documentation>If this tag finds an attribute in the XML that's notignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignorePropertiesand isn't abean property, should it throw an exception?
-          <paramtag>ignoreUnknownProperties Sets {@link #ignoreUnknownProperties}.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="parse">
-    <xsd:annotation>
-      <xsd:documentation>Parses the output of this tags body or of a given String as a Jelly scriptthen either outputting the Script as a variable or executing the script.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the text to be parsed by this parser
-          <paramtag>text The text to be parsed by this parser</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="XMLReader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XMLReader used for parsing</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="jellyParser">
-        <xsd:annotation>
-          <xsd:documentation>Sets the jellyParser.
-          <paramtag>jellyParser The jellyParser to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="otherwise">
-    <xsd:annotation>
-      <xsd:documentation>The otherwise block of a choose/when/otherwise group of tags
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="catch">
-    <xsd:annotation>
-      <xsd:documentation>A tag which catches exceptions thrown by its body.This allows conditional logic to be performed based on if exceptionsare thrown or to do some kind of custom exception logging logic.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which is exposed with the Exception that getsthrown by evaluating the body of this tag or which is set to null if there isno exception thrown.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="exceptions">
-        <xsd:annotation>
           <xsd:documentation>
-            <paramtag>exceptions The exceptions to set. Must be separated by ";"</paramtag>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="cause">
-        <xsd:annotation>
-          <xsd:documentation>
-            <paramtag>cause The cause to set.</paramtag>
+            Determine whether to use the Context ClassLoader (the one found by
+            calling
+
+            <code>Thread.currentThread().getContextClassLoader()</code>
+            )
+            to resolve/load classes.  If not
+            using Context ClassLoader, then the class-loading defaults to
+            using the calling-class' ClassLoader.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="default">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body ifnone of its preceeding sibling &lt;case&gt;tags have been evaluated.This tag must be contained within the body of some &lt;switch&gt;tag.
-        <seetag>SwitchTag</seetag>
-        <authortag>Rodney Waldhoff</authortag>
-        <versiontag>$Revision: 847 $ $Date: 2009-01-05 20:57:19 -0800 (Mon, 05 Jan 2009) $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="fallThru">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="remove">
-    <xsd:annotation>
-      <xsd:documentation>A tag which removes the variable of the given name from the current variable scope.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which will be removed by this tag..</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="thread">
-    <xsd:annotation>
-      <xsd:documentation>A tag that spawns the contained script in a separate thread
-        <authortag>&lt;a href="mailto:vinayc@apache.org"&gt;Vinay Chandran&lt;/a&gt;</authortag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the thread.
-          <paramtag>name The name to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="xmlOutput">
-        <xsd:annotation>
-          <xsd:documentation>Sets the destination of output</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Set the file which is generated from the output
-          <paramtag>name The output file name</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="case">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body ifmy valueattribute equals my ancestor &lt;switch&gt;tag's "on"attribute.This tag must be contained within the body of some &lt;switch&gt;tag.
-        <seetag>SwitchTag</seetag>
-        <authortag>Rodney Waldhoff</authortag>
-        <versiontag>$Revision: 847 $ $Date: 2009-01-05 20:57:19 -0800 (Mon, 05 Jan 2009) $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="fallThru">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="mute">
-    <xsd:annotation>
-      <xsd:documentation>A tag which executes its body but passing no output.
-        <p>Using this tag will still take the time to perform toString on each objectreturned to the output (but this toString value is discarded.A future version should go more internally so that this is avoided.</p>
-        <authortag>&lt;a href="mailto:paul@activemath.org"&gt;Paul Libbrecht&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="import">
-    <xsd:annotation>
-      <xsd:documentation>Imports another script.
-        <p>By default, the imported script does not have access tothe parent script's variable context. This behaviourmay be modified using the
-          <code>inherit</code>attribute.
-        </p>
-        <authortag>&lt;a href="mailto:bob@eng.werken.com"&gt;bob mcwhirter&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="inherit">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether property inheritence is enabled or disabled</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the URI (relative URI or absolute URL) for the script to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Sets the file for the script to evaluate.
-          <paramtag>file The file to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="forEach">
-    <xsd:annotation>
-      <xsd:documentation>Iterates over a collection, iterator or an array of objects.Uses the same syntax as the
-        <a href="http://java.sun.com/products/jsp/jstl/">JSTL</a>
-        <code>forEach</code>tag does.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="items">
-        <xsd:annotation>
-          <xsd:documentation>Sets the expression used to iterate over.This expression could resolve to an Iterator, Collection, Map, Array,Enumeration or comma separated String.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to export for the item being iterated over</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="indexVar">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to export the current index counter to</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="begin">
-        <xsd:annotation>
-          <xsd:documentation>Sets the starting index value</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="end">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ending index value</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="step">
-        <xsd:annotation>
-          <xsd:documentation>Sets the index increment step</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varStatus">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to export the current status to.The status is an implementation of the JSTL LoopTagStatus interface that providesthe following bean properties:
-          <ul><li>current - the current value of the loop items being iterated</li><li>index - the current index of the items being iterated</li><li>first - true if this is the first iteration, false otherwise</li><li>last - true if this is the last iteration, false otherwise</li><li>begin - the starting index of the loop</li><li>step - the stepping value of the loop</li><li>end - the end index of the loop</li></ul>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="if">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="test">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Jelly expression to evaluate. If this returns true, the body ofthe tag is evaluated
-          <paramtag>test the Jelly expression to evaluate</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="expr">
-    <xsd:annotation>
-      <xsd:documentation>A tag which evaluates an expression
-        <tagtag>out</tagtag>
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Jexl expression to evaluate.
-          <requiredtag>true</requiredtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="invokeStatic">
-    <xsd:annotation>
-      <xsd:documentation>A Tag which can invoke a static method on a class, without aninstance of the class being needed.
-        <p>Like the</p>org.apache.commons.jelly.tags.core.InvokeTag, this tag can take a set ofarguments using the org.apache.commons.jelly.tags.core.ArgTag. 
-        <p>The following attributes are required:
-          <br/>
-          <ul><li>var - The variable to assign the return of the method call to</li><li>method - The name of the static method to invoke</li><li>className - The name of the class containing the static method</li></ul>
-        </p>
-        <authortag>&lt;a href="mailto:robert@bull-enterprises.com&gt;Robert McIntosh&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable exported by this tag
-          <paramtag>var The variable name</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="exceptionVar">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of a variable that exports the exception thrown bythe method's invocation (if any)</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="method">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the method to invoke
-          <paramtag>method The method name</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the fully qualified class name containing the static method
-          <paramtag>className The name of the class</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="new">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a new object of the given type
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the class name of the object to instantiate</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Set the class loader to be used for instantiating application objectswhen required.
-          <paramtag>classLoader The new class loader to use, or &lt;code&gt;null&lt;/code&gt; to revert to the standard rules</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="useContextClassLoader">
-        <xsd:annotation>
-          <xsd:documentation>Determine whether to use the Context ClassLoader (the one found bycalling
-          <code>Thread.currentThread().getContextClassLoader()</code>)to resolve/load classes. If notusing Context ClassLoader, then the class-loading defaults tousing the calling-class' ClassLoader.
-          <paramtag>boolean determines whether to use JellyContext ClassLoader.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="setProperties">
-    <xsd:annotation>
-      <xsd:documentation>A tag which sets the bean properties on the given bean.So if you used it as follows, for example using the &lt;j:new&gt;tag.
-        <pre> &lt;j:new className="com.acme.Person" var="person"/&gt; &lt;j:setProperties object="${person}" name="James" location="${loc}"/&gt;</pre>Then it would set the name and location properties on the bean denoted bythe expression ${person}.
-        <p>This tag can also be nested inside a bean tag such as the &lt;useBean&gt;tagor a JellySwing tag to set one or more properties, maybe inside some conditionallogic.</p>
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt;and &gt;areescaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/core.xsd
@@ -1,17 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:core" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:core" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>The core Tags from the JSTL plus Jelly extensions.
-      </p>
-
+      <p>The core Tags from the JSTL plus Jelly extensions.</p>
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="whitespace">
+  <xsd:element name="jelly">
     <xsd:annotation>
-      <xsd:documentation>A simple tag used to preserve whitespace inside its body</xsd:documentation>
+      <xsd:documentation>The root Jelly tag which should be evaluated first</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -31,38 +27,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="while">
+  <xsd:element name="break">
     <xsd:annotation>
-      <xsd:documentation>A tag which performs an iteration while the result of an expression is true.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="test">
-        <xsd:annotation>
-          <xsd:documentation>Setter for the expression</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="when">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
+      <xsd:documentation>A tag which terminates the execution of the current &lt;forEach&gt; or &lt;while&gt;
+        loop. This tag can take an optional boolean test attribute which if its true
+        then the break occurs otherwise the loop continues processing.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -70,7 +39,22 @@
       </xsd:sequence>
       <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the expression to evaluate.</xsd:documentation>
+          <xsd:documentation>
+            Sets the Jelly expression to evaluate (optional).
+            If this is
+
+            <code>null</code>
+            or evaluates to
+
+
+            <code>true</code>
+            then the loop is terminated
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name to export indicating if the item was broken</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -87,156 +71,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="useList">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a List implementation and optionally
-        adds all of the elements identified by the items attribute.
-        The exact implementation of List can be specified via the
-        class attribute</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="ignoreUnknownProperties">
-        <xsd:annotation>
-          <xsd:documentation>If this tag finds an attribute in the XML that's not
-            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
-            bean property, should it throw an exception?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="useBean">
-    <xsd:annotation>
-      <xsd:documentation>
-        A tag which instantiates an instance of the given class
-        and then sets the properties on the bean.
-        The class can be specified via a java.lang.Class instance or
-        a String which will be used to load the class using either the current
-        thread's context class loader or the class loader used to load this
-        Jelly library.
-
-        This tag can be used it as follows,
-
-
-        <pre>
-          &lt;j:useBean var="person" class="com.acme.Person" name="James" location="${loc}"/&gt;
-          &lt;j:useBean var="order" class="${orderClass}" amount="12" price="123.456"/&gt;
-        </pre>
-
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="ignoreUnknownProperties">
-        <xsd:annotation>
-          <xsd:documentation>If this tag finds an attribute in the XML that's not
-            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
-            bean property, should it throw an exception?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="thread">
-    <xsd:annotation>
-      <xsd:documentation>A tag that spawns the contained script in a separate thread</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the thread.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="xmlOutput">
-        <xsd:annotation>
-          <xsd:documentation>Sets the destination of output</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Set the file which is generated from the output</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="switch">
-    <xsd:annotation>
-      <xsd:documentation>Executes the child &lt;case&gt; tag whose value equals my on attribute.
-        Executes a child &lt;default&gt; tag when present and no &lt;case&gt; tag has
-        yet matched.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="on">
-        <xsd:annotation>
-          <xsd:documentation>Sets the value to switch on.
-            Note that the org.apache.commons.jelly.expression.Expression is evaluated only once, when the
-            &lt;switch&gt; tag is evaluated.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="set">
     <xsd:annotation>
       <xsd:documentation>A tag which sets a variable from the result of an expression</xsd:documentation>
@@ -302,276 +136,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="setProperties">
-    <xsd:annotation>
-      <xsd:documentation>
-        A tag which sets the bean properties on the given bean.
-        So if you used it as follows, for example using the &lt;j:new&gt; tag.
-
-
-        <pre>
-          &lt;j:new className="com.acme.Person" var="person"/&gt;
-          &lt;j:setProperties object="${person}" name="James" location="${loc}"/&gt;
-        </pre>
-        Then it would set the name and location properties on the bean denoted by
-        the expression ${person}.
-
-
-        <p>
-          This tag can also be nested inside a bean tag such as the &lt;useBean&gt; tag
-          or a JellySwing tag to set one or more properties, maybe inside some conditional
-          logic.</p>
-
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="scope">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a new child variable scope for its body.
-        So any variables defined within its body will no longer be in scope
-        after this tag.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="remove">
-    <xsd:annotation>
-      <xsd:documentation>A tag which removes the variable of the given name from the current variable scope.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which will be removed by this tag..</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="parse">
-    <xsd:annotation>
-      <xsd:documentation>Parses the output of this tags body or of a given String as a Jelly script
-        then either outputting the Script as a variable or executing the script.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="XMLReader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XMLReader used for parsing</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="jellyParser">
-        <xsd:annotation>
-          <xsd:documentation>Sets the jellyParser.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="otherwise">
-    <xsd:annotation>
-      <xsd:documentation>The otherwise block of a choose/when/otherwise group of tags</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="new">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a new object of the given type</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the class name of the object to instantiate</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Set the class loader to be used for instantiating application objects
-            when required.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="useContextClassLoader">
-        <xsd:annotation>
-          <xsd:documentation>
-            Determine whether to use the Context ClassLoader (the one found by
-            calling
-
-            <code>Thread.currentThread().getContextClassLoader()</code>
-            )
-            to resolve/load classes.  If not
-            using Context ClassLoader, then the class-loading defaults to
-            using the calling-class' ClassLoader.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="mute">
-    <xsd:annotation>
-      <xsd:documentation>
-        A tag which executes its body but passing no output.
-
-
-        <p>
-          Using this tag will still take the time to perform toString on each object
-          returned to the output (but this toString value is discarded.
-          A future version should go more internally so that this is avoided.</p>
-
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="jelly">
-    <xsd:annotation>
-      <xsd:documentation>The root Jelly tag which should be evaluated first</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="invoke">
     <xsd:annotation>
       <xsd:documentation>A tag which calls a method in an object instantied by core:new</xsd:documentation>
@@ -615,67 +179,17 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="invokeStatic">
+  <xsd:element name="when">
     <xsd:annotation>
-      <xsd:documentation>
-        A Tag which can invoke a static method on a class, without an
-        instance of the class being needed.
-
-
-        <p>
-          Like the </p>
-        org.apache.commons.jelly.tags.core.InvokeTag, this tag can take a set of
-        arguments using the org.apache.commons.jelly.tags.core.ArgTag.
-
-
-        <p/>
-
-
-        <p>
-          The following attributes are required:
-
-
-          <ul>
-
-
-            <li>var - The variable to assign the return of the method call to</li>
-
-
-            <li>method - The name of the static method to invoke</li>
-
-
-            <li>className - The name of the class containing the static method</li>
-
-          </ul>
-
-        </p>
-
-      </xsd:documentation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="var">
+      <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="exceptionVar">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of a variable that exports the exception thrown by
-            the method's invocation (if any)</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="method">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the method to invoke</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the fully qualified class name containing the static method</xsd:documentation>
+          <xsd:documentation>Sets the expression to evaluate.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -692,7 +206,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="include">
     <xsd:annotation>
       <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
@@ -736,43 +249,49 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="import">
+  <xsd:element name="file">
     <xsd:annotation>
-      <xsd:documentation>
-        Imports another script.
-
-
-
-        <p>
-          By default, the imported script does not have access to
-          the parent script's variable context.  This behaviour
-          may be modified using the
-
-          <code>inherit</code>
-          attribute.
-
-        </p>
-
-      </xsd:documentation>
+      <xsd:documentation>A tag that pipes its body to a file denoted by the name attribute or to an in memory String
+        which is then output to a variable denoted by the var variable.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="inherit">
+      <xsd:attribute name="name">
         <xsd:annotation>
-          <xsd:documentation>Sets whether property inheritence is enabled or disabled</xsd:documentation>
+          <xsd:documentation>Sets the file name for the output</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="uri">
+      <xsd:attribute name="omitXmlDeclaration">
         <xsd:annotation>
-          <xsd:documentation>Sets the URI (relative URI or absolute URL) for the script to evaluate.</xsd:documentation>
+          <xsd:documentation>Sets whether the XML declaration should be output or not</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="file">
+      <xsd:attribute name="outputMode">
         <xsd:annotation>
-          <xsd:documentation>Sets the file for the script to evaluate.</xsd:documentation>
+          <xsd:documentation>Sets the output mode, whether XML or HTML</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="prettyPrint">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether pretty printing mode is turned on. The default is off so that whitespace is preserved</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encoding">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XML encoding mode, which defaults to UTF-8</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="append">
+        <xsd:annotation>
+          <xsd:documentation>Sets wether to append at the end of the file
+            (not really something you normally do with an XML file).</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the var.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -789,8 +308,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="if">
+  <xsd:element name="choose">
     <xsd:annotation>
       <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
     </xsd:annotation>
@@ -798,10 +316,31 @@
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="while">
+    <xsd:annotation>
+      <xsd:documentation>A tag which performs an iteration while the result of an expression is true.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
       <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the Jelly expression to evaluate. If this returns true, the body of
-            the tag is evaluated</xsd:documentation>
+          <xsd:documentation>Setter for the expression</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -818,7 +357,38 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="useList">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a List implementation and optionally
+        adds all of the elements identified by the items attribute.
+        The exact implementation of List can be specified via the
+        class attribute</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ignoreUnknownProperties">
+        <xsd:annotation>
+          <xsd:documentation>If this tag finds an attribute in the XML that's not
+            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
+            bean property, should it throw an exception?</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="getStatic">
     <xsd:annotation>
       <xsd:documentation>
@@ -881,14 +451,516 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="scope">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a new child variable scope for its body.
+        So any variables defined within its body will no longer be in scope
+        after this tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="whitespace">
+    <xsd:annotation>
+      <xsd:documentation>A simple tag used to preserve whitespace inside its body</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="arg">
+    <xsd:annotation>
+      <xsd:documentation>An argument to a org.apache.commons.jelly.tags.core.NewTag or org.apache.commons.jelly.tags.core.InvokeTag.
+        This tag MUST be enclosed within an org.apache.commons.jelly.tags.core.ArgTagParent
+        implementation.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="type">
+        <xsd:annotation>
+          <xsd:documentation>
+            The name of the argument class or type, if any.
+            This may be a fully specified class name or
+            a primitive type name
+            (
 
+            <code>boolean</code>
+            ,
+
+            <code>int</code>
+            ,
+
+            <code>double</code>
+            , etc.).
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>The (possibly null) value of this argument.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Set the class loader to be used for instantiating application objects
+            when required.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="useContextClassLoader">
+        <xsd:annotation>
+          <xsd:documentation>
+            Determine whether to use the Context ClassLoader (the one found by
+            calling
+
+            <code>Thread.currentThread().getContextClassLoader()</code>
+            )
+            to resolve/load classes.  If not
+            using Context ClassLoader, then the class-loading defaults to
+            using the calling-class' ClassLoader.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="switch">
+    <xsd:annotation>
+      <xsd:documentation>Executes the child &lt;case&gt; tag whose value equals my on attribute.
+        Executes a child &lt;default&gt; tag when present and no &lt;case&gt; tag has
+        yet matched.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="on">
+        <xsd:annotation>
+          <xsd:documentation>Sets the value to switch on.
+            Note that the org.apache.commons.jelly.expression.Expression is evaluated only once, when the
+            &lt;switch&gt; tag is evaluated.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="useBean">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which instantiates an instance of the given class
+        and then sets the properties on the bean.
+        The class can be specified via a java.lang.Class instance or
+        a String which will be used to load the class using either the current
+        thread's context class loader or the class loader used to load this
+        Jelly library.
+
+        This tag can be used it as follows,
+
+
+        <pre>
+          &lt;j:useBean var="person" class="com.acme.Person" name="James" location="${loc}"/&gt;
+          &lt;j:useBean var="order" class="${orderClass}" amount="12" price="123.456"/&gt;
+        </pre>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ignoreUnknownProperties">
+        <xsd:annotation>
+          <xsd:documentation>If this tag finds an attribute in the XML that's not
+            ignored by org.apache.commons.jelly.tags.core.UseBeanTag.ignoreProperties and isn't a
+            bean property, should it throw an exception?</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="parse">
+    <xsd:annotation>
+      <xsd:documentation>Parses the output of this tags body or of a given String as a Jelly script
+        then either outputting the Script as a variable or executing the script.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="XMLReader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XMLReader used for parsing</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="jellyParser">
+        <xsd:annotation>
+          <xsd:documentation>Sets the jellyParser.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="otherwise">
+    <xsd:annotation>
+      <xsd:documentation>The otherwise block of a choose/when/otherwise group of tags</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="catch">
+    <xsd:annotation>
+      <xsd:documentation>A tag which catches exceptions thrown by its body.
+        This allows conditional logic to be performed based on if exceptions
+        are thrown or to do some kind of custom exception logging logic.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which is exposed with the Exception that gets
+            thrown by evaluating the body of this tag or which is set to null if there is
+            no exception thrown.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="default">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body if
+        none of its preceeding sibling &lt;case&gt;
+        tags have been evaluated.
+
+        This tag must be contained within the body of some
+        &lt;switch&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="fallThru">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="remove">
+    <xsd:annotation>
+      <xsd:documentation>A tag which removes the variable of the given name from the current variable scope.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which will be removed by this tag..</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="thread">
+    <xsd:annotation>
+      <xsd:documentation>A tag that spawns the contained script in a separate thread</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the thread.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="xmlOutput">
+        <xsd:annotation>
+          <xsd:documentation>Sets the destination of output</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Set the file which is generated from the output</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="case">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body if
+        my value attribute equals my ancestor
+        &lt;switch&gt; tag's
+        "on" attribute.
+
+        This tag must be contained within the body of some
+        &lt;switch&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="fallThru">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="mute">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which executes its body but passing no output.
+
+
+        <p>
+          Using this tag will still take the time to perform toString on each object
+          returned to the output (but this toString value is discarded.
+          A future version should go more internally so that this is avoided.</p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="import">
+    <xsd:annotation>
+      <xsd:documentation>
+        Imports another script.
+
+
+
+        <p>
+          By default, the imported script does not have access to
+          the parent script's variable context.  This behaviour
+          may be modified using the
+
+          <code>inherit</code>
+          attribute.
+
+        </p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="inherit">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether property inheritence is enabled or disabled</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the URI (relative URI or absolute URL) for the script to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file for the script to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="forEach">
     <xsd:annotation>
       <xsd:documentation>
         Iterates over a collection, iterator or an array of objects.
         Uses the same syntax as the
 
-        <a>JSTL</a>
+        <a href="http://java.sun.com/products/jsp/jstl/">JSTL</a>
 
 
         <code>forEach</code>
@@ -981,50 +1053,18 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="file">
+  <xsd:element name="if">
     <xsd:annotation>
-      <xsd:documentation>A tag that pipes its body to a file denoted by the name attribute or to an in memory String
-        which is then output to a variable denoted by the var variable.</xsd:documentation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="name">
+      <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the file name for the output</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="omitXmlDeclaration">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the XML declaration should be output or not</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="outputMode">
-        <xsd:annotation>
-          <xsd:documentation>Sets the output mode, whether XML or HTML</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="prettyPrint">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether pretty printing mode is turned on. The default is off so that whitespace is preserved</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encoding">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XML encoding mode, which defaults to UTF-8</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="append">
-        <xsd:annotation>
-          <xsd:documentation>Sets wether to append at the end of the file
-            (not really something you normally do with an XML file).</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the var.</xsd:documentation>
+          <xsd:documentation>Sets the Jelly expression to evaluate. If this returns true, the body of
+            the tag is evaluated</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -1041,7 +1081,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="expr">
     <xsd:annotation>
       <xsd:documentation>A tag which evaluates an expression</xsd:documentation>
@@ -1069,68 +1108,42 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="default">
+  <xsd:element name="invokeStatic">
     <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body if
-        none of its preceeding sibling &lt;case&gt;
-        tags have been evaluated.
+      <xsd:documentation>
+        A Tag which can invoke a static method on a class, without an
+        instance of the class being needed.
 
-        This tag must be contained within the body of some
-        &lt;switch&gt; tag.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="fallThru">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
 
-  <xsd:element name="choose">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+        <p>
+          Like the </p>
+        org.apache.commons.jelly.tags.core.InvokeTag, this tag can take a set of
+        arguments using the org.apache.commons.jelly.tags.core.ArgTag.
 
-  <xsd:element name="catch">
-    <xsd:annotation>
-      <xsd:documentation>A tag which catches exceptions thrown by its body.
-        This allows conditional logic to be performed based on if exceptions
-        are thrown or to do some kind of custom exception logging logic.</xsd:documentation>
+
+        <p/>
+
+
+        <p>
+          The following attributes are required:
+
+
+          <ul>
+
+
+            <li>var - The variable to assign the return of the method call to</li>
+
+
+            <li>method - The name of the static method to invoke</li>
+
+
+            <li>className - The name of the class containing the static method</li>
+
+          </ul>
+
+        </p>
+
+      </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -1138,9 +1151,23 @@
       </xsd:sequence>
       <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which is exposed with the Exception that gets
-            thrown by evaluating the body of this tag or which is set to null if there is
-            no exception thrown.</xsd:documentation>
+          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="exceptionVar">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of a variable that exports the exception thrown by
+            the method's invocation (if any)</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="method">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the method to invoke</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the fully qualified class name containing the static method</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -1157,131 +1184,22 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="case">
+  <xsd:element name="new">
     <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body if
-        my value attribute equals my ancestor
-        &lt;switch&gt; tag's
-        "on" attribute.
-
-        This tag must be contained within the body of some
-        &lt;switch&gt; tag.</xsd:documentation>
+      <xsd:documentation>A tag which creates a new object of the given type</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="fallThru">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="break">
-    <xsd:annotation>
-      <xsd:documentation>A tag which terminates the execution of the current &lt;forEach&gt; or &lt;while&gt;
-        loop. This tag can take an optional boolean test attribute which if its true
-        then the break occurs otherwise the loop continues processing.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="test">
-        <xsd:annotation>
-          <xsd:documentation>
-            Sets the Jelly expression to evaluate (optional).
-            If this is
-
-            <code>null</code>
-            or evaluates to
-
-
-            <code>true</code>
-            then the loop is terminated
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the variable name to export indicating if the item was broken</xsd:documentation>
+          <xsd:documentation>Sets the name of the variable exported by this tag</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="trim">
+      <xsd:attribute name="className">
         <xsd:annotation>
-          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
-            Defaults to true so whitespace is trimmed</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
-            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="">
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="arg">
-    <xsd:annotation>
-      <xsd:documentation>An argument to a org.apache.commons.jelly.tags.core.NewTag or org.apache.commons.jelly.tags.core.InvokeTag.
-        This tag MUST be enclosed within an org.apache.commons.jelly.tags.core.ArgTagParent
-        implementation.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="type">
-        <xsd:annotation>
-          <xsd:documentation>
-            The name of the argument class or type, if any.
-            This may be a fully specified class name or
-            a primitive type name
-            (
-
-            <code>boolean</code>
-            ,
-
-            <code>int</code>
-            ,
-
-            <code>double</code>
-            , etc.).
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>The (possibly null) value of this argument.</xsd:documentation>
+          <xsd:documentation>Sets the class name of the object to instantiate</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="classLoader">
@@ -1318,5 +1236,44 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="setProperties">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag which sets the bean properties on the given bean.
+        So if you used it as follows, for example using the &lt;j:new&gt; tag.
 
+
+        <pre>
+          &lt;j:new className="com.acme.Person" var="person"/&gt;
+          &lt;j:setProperties object="${person}" name="James" location="${loc}"/&gt;
+        </pre>
+        Then it would set the name and location properties on the bean denoted by
+        the expression ${person}.
+
+
+        <p>
+          This tag can also be nested inside a bean tag such as the &lt;useBean&gt; tag
+          or a JellySwing tag to set one or more properties, maybe inside some conditional
+          logic.</p>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether whitespace inside this tag should be trimmed or not.
+            Defaults to true so whitespace is trimmed</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be escaped as text (so that &lt; and &gt; are
+            escaped as &amp;lt; and &amp;gt;), which is the default or leave the text as XML.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/define.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/define.xsd
@@ -1,42 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:define" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:define" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>Tag library which allows the creation of new tags using Jelly script itself.
-      </p>
-
+      <p>Tag library which allows the creation of new tags using Jelly script itself.</p>
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="taglib">
+  <xsd:element name="invoke">
     <xsd:annotation>
-      <xsd:documentation>The &lt;taglib&gt; tag is used to define a new tag library
-        using a Jelly script. The tag library is identified by its
-        URI.
-
-        The tags for a taglib are declared using the org.apache.commons.jelly.tags.define.TagTag.
-
-        You can 'inherit' tags from a previously defined taglib, as well,
-        allowing runtime extension of tag libraries</xsd:documentation>
+      <xsd:documentation>The &lt;invoke&gt; tag will invoke a given Script instance.
+        It can be used with the &lt;script&gt; tag which defines scripts
+        as variables that can later be invoked by this &lt;invoke&gt; tag.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="uri">
+      <xsd:attribute name="script">
         <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI to register this new dynamic tag library with</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="inherit">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether this dynamic tag should inherit from the current existing tag library
-            of the same URI. This feature is enabled by default so that tags can easily be
-            some tags can be overridden in an existing library, such as when making Mock Tags.
-
-            You can disable this option if you want to disable any tags in the base library,
-            turning them into just normal static XML.</xsd:documentation>
+          <xsd:documentation>Sets the Script to be invoked by this tag, which typically has been previously defined by the use of the &lt;script&gt; tag.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -51,7 +32,241 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="extend">
+    <xsd:annotation>
+      <xsd:documentation>&lt;extend&gt; is used to extend a dynamic tag defined in an inherited
+        dynamic tag library</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="bean">
+    <xsd:annotation>
+      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
+        the tag set the bean properties..</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ClassLoader to use to load the class.
+            If no value is set then the current threads context class loader is used.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic tag will output its results as. This defaults to 'var' though this property can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="classLoader">
+    <xsd:annotation>
+      <xsd:documentation>
+        Creates a new
 
+        <code>URLClassLoader</code>
+        to dynamically
+        load tags froms.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>the variable to store the class loader in</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="url">
+        <xsd:annotation>
+          <xsd:documentation>the url to load the classes from</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ClassLoader to use to load the class.
+            If no value is set then the current threads context class loader is used.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="script">
+    <xsd:annotation>
+      <xsd:documentation>&lt;script&gt; tag is used to assign a Script object
+        to a variable. The script can then be called whenever the user wishes
+        maybe from inside an expression or more typically via the &lt;invoke&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="invokeBody">
+    <xsd:annotation>
+      <xsd:documentation>&lt;invokeBody&gt; tag is used inside a &lt;tag&gt; tag
+        (i.e. the definition of a dynamic tag) to invoke the tags body when
+        the tag is invoked.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="super">
+    <xsd:annotation>
+      <xsd:documentation>&lt;super&gt; tag is used to invoke a parent tag implementation, when
+        a tag extends an existing tag</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="attribute">
+    <xsd:annotation>
+      <xsd:documentation>This tag is bound onto a Java Bean class. When the tag is invoked a bean will be created
+        using the tags attributes.
+        The bean may also have an invoke method called invoke(), run(), execute() or some such method
+        which will be invoked after the bean has been configured.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="required">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether this attribute is mandatory or not</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="defaultValue">
+        <xsd:annotation>
+          <xsd:documentation>Sets the default value of this attribute</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="tag">
     <xsd:annotation>
       <xsd:documentation>&lt;tag&gt; is used to define a new tag
@@ -81,16 +296,32 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="super">
+  <xsd:element name="dynaBean">
     <xsd:annotation>
-      <xsd:documentation>&lt;super&gt; tag is used to invoke a parent tag implementation, when
-        a tag extends an existing tag</xsd:documentation>
+      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
+        the tag set the bean properties..</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="dynaClass">
+        <xsd:annotation>
+          <xsd:documentation>Sets the org.apache.commons.beanutils.DynaClass which will be bound to this dynamic tag.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
@@ -103,35 +334,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="script">
-    <xsd:annotation>
-      <xsd:documentation>&lt;script&gt; tag is used to assign a Script object
-        to a variable. The script can then be called whenever the user wishes
-        maybe from inside an expression or more typically via the &lt;invoke&gt; tag.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="jellyBean">
     <xsd:annotation>
       <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
@@ -186,21 +388,34 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="invoke">
+  <xsd:element name="taglib">
     <xsd:annotation>
-      <xsd:documentation>The &lt;invoke&gt; tag will invoke a given Script instance.
-        It can be used with the &lt;script&gt; tag which defines scripts
-        as variables that can later be invoked by this &lt;invoke&gt; tag.</xsd:documentation>
+      <xsd:documentation>The &lt;taglib&gt; tag is used to define a new tag library
+        using a Jelly script. The tag library is identified by its
+        URI.
+
+        The tags for a taglib are declared using the org.apache.commons.jelly.tags.define.TagTag.
+
+        You can 'inherit' tags from a previously defined taglib, as well,
+        allowing runtime extension of tag libraries</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="script">
+      <xsd:attribute name="uri">
         <xsd:annotation>
-          <xsd:documentation>Sets the Script to be invoked by this tag, which typically has been previously
-            defined by the use of the &lt;script&gt; tag.</xsd:documentation>
+          <xsd:documentation>Sets the namespace URI to register this new dynamic tag library with</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="inherit">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether this dynamic tag should inherit from the current existing tag library
+            of the same URI. This feature is enabled by default so that tags can easily be
+            some tags can be overridden in an existing library, such as when making Mock Tags.
+
+            You can disable this option if you want to disable any tags in the base library,
+            turning them into just normal static XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -215,248 +430,4 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="invokeBody">
-    <xsd:annotation>
-      <xsd:documentation>&lt;invokeBody&gt; tag is used inside a &lt;tag&gt; tag
-        (i.e. the definition of a dynamic tag) to invoke the tags body when
-        the tag is invoked.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="extend">
-    <xsd:annotation>
-      <xsd:documentation>&lt;extend&gt; is used to extend a dynamic tag defined in an inherited
-        dynamic tag library</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="dynaBean">
-    <xsd:annotation>
-      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
-        the tag set the bean properties..</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
-            tag will output its results as. This defaults to 'var' though this property
-            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="dynaClass">
-        <xsd:annotation>
-          <xsd:documentation>Sets the org.apache.commons.beanutils.DynaClass which will be bound to this dynamic tag.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="">
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="classLoader">
-    <xsd:annotation>
-      <xsd:documentation>
-        Creates a new
-
-        <code>URLClassLoader</code>
-        to dynamically
-        load tags froms.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="url">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ClassLoader to use to load the class.
-            If no value is set then the current threads context class
-            loader is used.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
-            tag will output its results as. This defaults to 'var' though this property
-            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="bean">
-    <xsd:annotation>
-      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
-        the tag set the bean properties..</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ClassLoader to use to load the class.
-            If no value is set then the current threads context class
-            loader is used.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
-            tag will output its results as. This defaults to 'var' though this property
-            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="attribute">
-    <xsd:annotation>
-      <xsd:documentation>This tag is bound onto a Java Bean class. When the tag is invoked a bean will be created
-        using the tags attributes.
-        The bean may also have an invoke method called invoke(), run(), execute() or some such method
-        which will be invoked after the bean has been configured.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="required">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether this attribute is mandatory or not</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="defaultValue">
-        <xsd:annotation>
-          <xsd:documentation>Sets the default value of this attribute</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/define.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/define.xsd
@@ -1,32 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:define" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:define" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>Tag library which allows the creation of new tags using Jelly script itself.</p>
+
+      <p>Tag library which allows the creation of new tags using Jelly script itself.
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="invoke">
+
+  <xsd:element name="taglib">
     <xsd:annotation>
-      <xsd:documentation>The &lt;invoke&gt;tag will invoke a given Script instance.It can be used with the &lt;script&gt;tag which defines scriptsas variables that can later be invoked by this &lt;invoke&gt;tag.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>The &lt;taglib&gt; tag is used to define a new tag library
+        using a Jelly script. The tag library is identified by its
+        URI.
+
+        The tags for a taglib are declared using the org.apache.commons.jelly.tags.define.TagTag.
+
+        You can 'inherit' tags from a previously defined taglib, as well,
+        allowing runtime extension of tag libraries</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="script">
+      <xsd:attribute name="uri">
         <xsd:annotation>
-          <xsd:documentation>Sets the Script to be invoked by this tag, which typically has been previouslydefined by the use of the &lt;script&gt;tag.</xsd:documentation>
+          <xsd:documentation>Sets the namespace URI to register this new dynamic tag library with</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="inherit">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether this dynamic tag should inherit from the current existing tag library
+            of the same URI. This feature is enabled by default so that tags can easily be
+            some tags can be overridden in an existing library, such as when making Mock Tags.
+
+            You can disable this option if you want to disable any tags in the base library,
+            turning them into just normal static XML.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -38,47 +51,14 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="extend">
+
+  <xsd:element name="tag">
     <xsd:annotation>
-      <xsd:documentation>&lt;extend&gt;is used to extend a dynamic tag defined in an inheriteddynamic tag library
-        <p/>
-        <authortag>&lt;a href="mailto:tima@intalio.com"&gt;Tim Anderson&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-        <seetag>SuperTag</seetag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="bean">
-    <xsd:annotation>
-      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes ofthe tag set the bean properties..
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>&lt;tag&gt; is used to define a new tag
+        using a Jelly script to implement the behaviour of the tag.
+        Parameters can be passed into the new tag using normal XML attribute
+        notations. Inside the body of the tag definition, the attributes can
+        be accessed as normal Jelly variables.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -89,27 +69,7 @@
           <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ClassLoader to use to load the class.If no value is set then the current threads context classloader is used.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamictag will output its results as. This defaults to 'var' though this propertycan be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -121,58 +81,17 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="classLoader">
+
+  <xsd:element name="super">
     <xsd:annotation>
-      <xsd:documentation>Creates a new
-        <code>URLClassLoader</code>to dynamicallyload tags froms.
-        <authortag>&lt;a href="mailto:stephenh@chase3000.com"&gt;Stephen Haberman&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>&lt;super&gt; tag is used to invoke a parent tag implementation, when
+        a tag extends an existing tag</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>
-            <paramtag>var the variable to store the class loader in</paramtag>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="url">
-        <xsd:annotation>
-          <xsd:documentation>
-            <paramtag>url the url to load the classes from</paramtag>
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ClassLoader to use to load the class.If no value is set then the current threads context classloader is used.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamictag will output its results as. This defaults to 'var' though this propertycan be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -184,12 +103,12 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="script">
     <xsd:annotation>
-      <xsd:documentation>&lt;script&gt;tag is used to assign a Script objectto a variable. The script can then be called whenever the user wishesmaybe from inside an expression or more typically via the &lt;invoke&gt;tag.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>&lt;script&gt; tag is used to assign a Script object
+        to a variable. The script can then be called whenever the user wishes
+        maybe from inside an expression or more typically via the &lt;invoke&gt; tag.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -205,7 +124,57 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="jellyBean">
+    <xsd:annotation>
+      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
+        the tag set the bean properties. After the body of this tag is invoked
+        then the beans invoke() method will be called, if the bean has one.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="method">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the method to invoke on the bean.
+            This defaults to "run" so that Runnable objects can be
+            invoked, but this property can be set to whatever is required,
+            such as "execute" or "invoke"</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ClassLoader to use to load the class.
+            If no value is set then the current threads context class
+            loader is used.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -217,23 +186,47 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="invoke">
+    <xsd:annotation>
+      <xsd:documentation>The &lt;invoke&gt; tag will invoke a given Script instance.
+        It can be used with the &lt;script&gt; tag which defines scripts
+        as variables that can later be invoked by this &lt;invoke&gt; tag.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="script">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Script to be invoked by this tag, which typically has been previously
+            defined by the use of the &lt;script&gt; tag.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="invokeBody">
     <xsd:annotation>
-      <xsd:documentation>&lt;invokeBody&gt;tag is used inside a &lt;tag&gt;tag(i.e. the definition of a dynamic tag) to invoke the tags body whenthe tag is invoked.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>&lt;invokeBody&gt; tag is used inside a &lt;tag&gt; tag
+        (i.e. the definition of a dynamic tag) to invoke the tags body when
+        the tag is invoked.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -245,24 +238,22 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="super">
+
+  <xsd:element name="extend">
     <xsd:annotation>
-      <xsd:documentation>&lt;super&gt;tag is used to invoke a parent tag implementation, whena tag extends an existing tag
-        <authortag>&lt;a href="mailto:tima@intalio.com"&gt;Tim Anderson&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-        <seetag>ExtendTag</seetag>
-      </xsd:documentation>
+      <xsd:documentation>&lt;extend&gt; is used to extend a dynamic tag defined in an inherited
+        dynamic tag library</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="trim">
+      <xsd:attribute name="name">
         <xsd:annotation>
-          <xsd:documentation/>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -274,13 +265,167 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="dynaBean">
+    <xsd:annotation>
+      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
+        the tag set the bean properties..</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="dynaClass">
+        <xsd:annotation>
+          <xsd:documentation>Sets the org.apache.commons.beanutils.DynaClass which will be bound to this dynamic tag.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="">
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="classLoader">
+    <xsd:annotation>
+      <xsd:documentation>
+        Creates a new
+
+        <code>URLClassLoader</code>
+        to dynamically
+        load tags froms.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="url">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ClassLoader to use to load the class.
+            If no value is set then the current threads context class
+            loader is used.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="bean">
+    <xsd:annotation>
+      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes of
+        the tag set the bean properties..</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="className">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the ClassLoader to use to load the class.
+            If no value is set then the current threads context class
+            loader is used.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="varAttribute">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamic
+            tag will output its results as. This defaults to 'var' though this property
+            can be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="attribute">
     <xsd:annotation>
-      <xsd:documentation>This tag is bound onto a Java Bean class. When the tag is invoked a bean will be createdusing the tags attributes.The bean may also have an invoke method called invoke(), run(), execute() or some such methodwhich will be invoked after the bean has been configured.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <authortag>&lt;a href="mailto:jason@zenplex.com"&gt;Jason van Zyl&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>This tag is bound onto a Java Bean class. When the tag is invoked a bean will be created
+        using the tags attributes.
+        The bean may also have an invoke method called invoke(), run(), execute() or some such method
+        which will be invoked after the bean has been configured.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -306,11 +451,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -318,173 +458,5 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="tag">
-    <xsd:annotation>
-      <xsd:documentation>&lt;tag&gt;is used to define a new tagusing a Jelly script to implement the behaviour of the tag.Parameters can be passed into the new tag using normal XML attributenotations. Inside the body of the tag definition, the attributes canbe accessed as normal Jelly variables.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="dynaBean">
-    <xsd:annotation>
-      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes ofthe tag set the bean properties..
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamictag will output its results as. This defaults to 'var' though this propertycan be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="dynaClass">
-        <xsd:annotation>
-          <xsd:documentation>Sets the org.apache.commons.beanutils.DynaClasswhich will be bound to this dynamic tag.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="jellyBean">
-    <xsd:annotation>
-      <xsd:documentation>Binds a Java bean to the given named Jelly tag so that the attributes ofthe tag set the bean properties. After the body of this tag is invokedthen the beans invoke() method will be called, if the bean has one.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="method">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the method to invoke on the bean.This defaults to "run" so that Runnable objects can beinvoked, but this property can be set to whatever is required,such as "execute" or "invoke"</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the tag to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="className">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Java class name to use for the tag</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the ClassLoader to use to load the class.If no value is set then the current threads context classloader is used.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="varAttribute">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute used to define the bean variable that this dynamictag will output its results as. This defaults to 'var' though this propertycan be used to change this if it conflicts with a bean property called 'var'.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="taglib">
-    <xsd:annotation>
-      <xsd:documentation>The &lt;taglib&gt;tag is used to define a new tag libraryusing a Jelly script. The tag library is identified by its URI.The tags for a taglib are declared using the org.apache.commons.jelly.tags.define.TagTag.You can 'inherit' tags from a previously defined taglib, as well,allowing runtime extension of tag libraries
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI to register this new dynamic tag library with</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="inherit">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether this dynamic tag should inherit from the current existing tag libraryof the same URI. This feature is enabled by default so that tags can easily besome tags can be overridden in an existing library, such as when making Mock Tags.You can disable this option if you want to disable any tags in the base library,turning them into just normal static XML.
-          <paramtag>inherit The inherit to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/dynabean.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/dynabean.xsd
@@ -1,18 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:dynabean" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:dynabean" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>A tag library for creating new DynaClass and DynaBean objects from the 
-        <a href="http://commons.apache.org/beanutils/">beanutils</a>library
+
+      <p>
+        A tag library for creating new DynaClass and DynaBean objects from the
+
+
+        <a>beanutils</a>
+        library
+
       </p>
+
     </xsd:documentation>
   </xsd:annotation>
+
   <xsd:element name="set">
     <xsd:annotation>
-      <xsd:documentation>A tag which sets a variable from the result of an expression
-        <authortag>Theo Niemeijer</authortag>
-        <versiontag>1.0</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which sets a variable from the result of an expression</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -25,7 +30,11 @@
       </xsd:attribute>
       <xsd:attribute name="scope">
         <xsd:annotation>
-          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' willset this value in the parent scope. When Jelly is run from inside a Servlet environmentthen other scopes will be available such as 'request', 'session' or 'application'.Other applications may implement their own custom scopes.</xsd:documentation>
+          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' will
+            set this value in the parent scope. When Jelly is run from inside a Servlet environment
+            then other scopes will be available such as 'request', 'session' or 'application'.
+
+            Other applications may implement their own custom scopes.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="value">
@@ -48,11 +57,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -60,88 +64,14 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="dynaclass">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates and defines and creates a DynaClassThe DynaClass object is placed by name in the context,so that a DynaBean tag can use it by name to instantiatea DynaBean object
-        <authortag>Theo Niemeijer</authortag>
-        <versiontag>1.0</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the new DynaClass</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable to export the DynaClass instance</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="dynabean">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition
-        <authortag>Theo Niemeijer</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="dynaclass">
-        <xsd:annotation>
-          <xsd:documentation>Sets the DynaClass of the new instance to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable to export the new DynaBean instance to</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="property">
     <xsd:annotation>
-      <xsd:documentation>DynaProperty tag defines a property of a DynaClassIt can only exist inside a DynaClass parent contextThe properties are added to the properties arrayof the parent context, and will be used tocreate the DynaClass object
-        <authortag>Theo Niemeijer</authortag>
-        <versiontag>1.0</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>DynaProperty tag defines a property of a DynaClass
+        It can only exist inside a DynaClass parent context
+        The properties are added to the properties array
+        of the parent context, and will be used to
+        create the DynaClass object</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -167,7 +97,36 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="dynaclass">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates and defines and creates a DynaClass
+        The DynaClass object is placed by name in the context,
+        so that a DynaBean tag can use it by name to instantiate
+        a DynaBean object</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the new DynaClass</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable to export the DynaClass instance</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -179,4 +138,36 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="dynabean">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="dynaclass">
+        <xsd:annotation>
+          <xsd:documentation>Sets the DynaClass of the new instance to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable to export the new DynaBean instance to</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/dynabean.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/dynabean.xsd
@@ -1,20 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:dynabean" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:dynabean" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>
-        A tag library for creating new DynaClass and DynaBean objects from the
-
-
-        <a>beanutils</a>
-        library
-
+      <p>A tag library for creating new DynaClass and DynaBean objects from the
+        <a href="http://commons.apache.org/beanutils/">beanutils</a> library
       </p>
-
     </xsd:documentation>
   </xsd:annotation>
-
   <xsd:element name="set">
     <xsd:annotation>
       <xsd:documentation>A tag which sets a variable from the result of an expression</xsd:documentation>
@@ -30,9 +22,7 @@
       </xsd:attribute>
       <xsd:attribute name="scope">
         <xsd:annotation>
-          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' will
-            set this value in the parent scope. When Jelly is run from inside a Servlet environment
-            then other scopes will be available such as 'request', 'session' or 'application'.
+          <xsd:documentation>Sets the variable scope for this variable. For example setting this value to 'parent' will set this value in the parent scope. When Jelly is run from inside a Servlet environment then other scopes will be available such as 'request', 'session' or 'application'.
 
             Other applications may implement their own custom scopes.</xsd:documentation>
         </xsd:annotation>
@@ -64,7 +54,67 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="dynaclass">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates and defines and creates a DynaClass
+        The DynaClass object is placed by name in the context, so that a DynaBean tag can use it by name to instantiate a DynaBean object</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the new DynaClass</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable to export the DynaClass instance</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="dynabean">
+    <xsd:annotation>
+      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="dynaclass">
+        <xsd:annotation>
+          <xsd:documentation>Sets the DynaClass of the new instance to create</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable to export the new DynaBean instance to</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="property">
     <xsd:annotation>
       <xsd:documentation>DynaProperty tag defines a property of a DynaClass
@@ -104,70 +154,4 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="dynaclass">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates and defines and creates a DynaClass
-        The DynaClass object is placed by name in the context,
-        so that a DynaBean tag can use it by name to instantiate
-        a DynaBean object</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the new DynaClass</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable to export the DynaClass instance</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="dynabean">
-    <xsd:annotation>
-      <xsd:documentation>A tag which conditionally evaluates its body based on some condition</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="dynaclass">
-        <xsd:annotation>
-          <xsd:documentation>Sets the DynaClass of the new instance to create</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable to export the new DynaBean instance to</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/fmt.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/fmt.xsd
@@ -1,58 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:fmt" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:fmt" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation/>
   </xsd:annotation>
-  <xsd:element name="setBundle">
+
+  <xsd:element name="timeZone">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the bundle settingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="basename">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="scope">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="formatDate">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;formatDate&gt;, the date and time formattingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-        <tasktag>i18n exception message</tasktag>
-      </xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;timeZone&gt;, the time zone loading
+        tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -60,66 +15,10 @@
       </xsd:sequence>
       <xsd:attribute name="value">
         <xsd:annotation>
-          <xsd:documentation>Setter for property value.
-          <paramtag>value New value of property value.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="type">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property type.
-          <paramtag>type New value of property type.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="dateStyle">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property dataStyle.
-          <paramtag>dataStyle New value of property dataStyle.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="timeStyle">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property timeStyle.
-          <paramtag>timeStyle New value of property timeStyle.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="pattern">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property pattern.
-          <paramtag>pattern New value of property pattern.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="timeZone">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property timeZone.
-          <paramtag>timeZone New value of property timeZone.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property var.
-          <paramtag>var New value of property var.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="scope">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property scope.
-          <paramtag>scope New value of property scope.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property value.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -131,12 +30,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="setTimeZone">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;setTimeZone&gt;, the time zone settingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;setTimeZone&gt;, the time zone setting
+        tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -162,11 +60,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -174,49 +67,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="param">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;param&gt;, the parameter settingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>1.1</versiontag>
-        <tasktag>handle body content trimming</tasktag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property value.
-          <paramtag>value New value of property value.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="setLocale">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the locale settingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>1.2</versiontag>
-        <tasktag>decide how to implement setResponseLocale</tasktag>
-      </xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the locale setting
+        tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -242,7 +97,39 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="setBundle">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the bundle setting
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="basename">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="scope">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -254,13 +141,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="timeZone">
+
+  <xsd:element name="param">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;timeZone&gt;, the time zone loadingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-        <tasktag>decide how to implement setResponseLocale</tasktag>
-      </xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;param&gt;, the parameter setting
+        tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -268,17 +153,10 @@
       </xsd:sequence>
       <xsd:attribute name="value">
         <xsd:annotation>
-          <xsd:documentation>Setter for property value.
-          <paramtag>value New value of property value.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property value.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -290,56 +168,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="bundle">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;bundle&gt;, the resource bundle loadingtag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>1.1</versiontag>
-        <todotag>decide how to implement setResponseLocale</todotag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="basename">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property basename.
-          <paramtag>basename New value of property basename.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="prefix">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property prefix.
-          <paramtag>prefix New value of property prefix.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="message">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;message&gt;, the lookup uplocalized message tag in JSTL.
-        <authortag>&lt;a href="mailto:willievu@yahoo.com"&gt;Willie Vu&lt;/a&gt;</authortag>
-        <versiontag>1.1</versiontag>
-        <tasktag>decide how to implement setResponseLocale</tasktag>
-      </xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;message&gt;, the lookup up
+        localized message tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -347,38 +180,25 @@
       </xsd:sequence>
       <xsd:attribute name="key">
         <xsd:annotation>
-          <xsd:documentation>Setter for property key.
-          <paramtag>key New value of property key.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property key.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="bundle">
         <xsd:annotation>
-          <xsd:documentation>Setter for property bundle.
-          <paramtag>bundle New value of property bundle.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property bundle.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Setter for property var.
-          <paramtag>var New value of property var.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property var.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="scope">
         <xsd:annotation>
-          <xsd:documentation>Setter for property scope.
-          <paramtag>scope New value of property scope.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Setter for property scope.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -390,4 +210,99 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="formatDate">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;formatDate&gt;, the date and time formatting
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="type">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property type.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="dateStyle">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property dataStyle.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="timeStyle">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property timeStyle.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="pattern">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property pattern.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="timeZone">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property timeZone.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property var.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="scope">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property scope.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="bundle">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;bundle&gt;, the resource bundle loading
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="basename">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property basename.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="prefix">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property prefix.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/fmt.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/fmt.xsd
@@ -1,110 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:fmt" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:fmt" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation/>
   </xsd:annotation>
-
-  <xsd:element name="timeZone">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;timeZone&gt;, the time zone loading
-        tag in JSTL.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property value.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="setTimeZone">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;setTimeZone&gt;, the time zone setting
-        tag in JSTL.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="scope">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="setLocale">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the locale setting
-        tag in JSTL.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="variant">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="scope">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="setBundle">
     <xsd:annotation>
       <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the bundle setting
@@ -141,76 +39,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="param">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;param&gt;, the parameter setting
-        tag in JSTL.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property value.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="message">
-    <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;message&gt;, the lookup up
-        localized message tag in JSTL.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="key">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property key.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="bundle">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property bundle.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property var.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="scope">
-        <xsd:annotation>
-          <xsd:documentation>Setter for property scope.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="formatDate">
     <xsd:annotation>
       <xsd:documentation>Support for tag handlers for &lt;formatDate&gt;, the date and time formatting
@@ -272,11 +100,132 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="setTimeZone">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;setTimeZone&gt;, the time zone setting
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="scope">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="param">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;param&gt;, the parameter setting
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="setLocale">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;setLocale&gt;, the locale setting
+        tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="variant">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="scope">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="timeZone">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;timeZone&gt;, the time zone loading tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="bundle">
     <xsd:annotation>
-      <xsd:documentation>Support for tag handlers for &lt;bundle&gt;, the resource bundle loading
-        tag in JSTL.</xsd:documentation>
+      <xsd:documentation>Support for tag handlers for &lt;bundle&gt;, the resource bundle loading tag in JSTL.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -304,5 +253,45 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="message">
+    <xsd:annotation>
+      <xsd:documentation>Support for tag handlers for &lt;message&gt;, the lookup up
+        localized message tag in JSTL.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="key">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property key.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="bundle">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property bundle.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property var.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="scope">
+        <xsd:annotation>
+          <xsd:documentation>Setter for property scope.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/junit.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/junit.xsd
@@ -1,238 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:junit" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:junit" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>
-        A collection of
-
-        <a>JUnit</a>
-        tags for
-        performing unit tests written in Jelly script.
-
+      <p>A collection of
+        <a href="http://www.junit.org">JUnit</a> tags for performing unit tests written in Jelly script.
       </p>
-
-
-
       <p>
         The &lt;suite&gt; tag allows a test suite to be created and then test cases can either
         be individually ran or the whole suite ran.
       </p>
-
-
       <p>
         The &lt;case&gt; tag allows a single test case to be created as part of a suite.
       </p>
-
-
       <p>
         The &lt;run&gt; tag can be used to run a given Test, TestCase or TestSuite
       </p>
-
-
-
       <p>
         There is an example of these tags in action
-
-
-        <a>here</a>
-
+        <a href="http://cvs.apache.org/viewcvs.cgi/jakarta-commons/jelly/jelly-tags/junit/src/test/org/apache/commons/jelly/tags/junit/suite.jelly?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup">here</a>
       </p>
-
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="suite">
-    <xsd:annotation>
-      <xsd:documentation>Represents a collection of TestCases.. This tag is analagous to
-        JUnit's TestSuite class.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the test suite whichi is exported</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of this test suite</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="run">
-    <xsd:annotation>
-      <xsd:documentation>This tag will run the given Test which could be an individual TestCase or a TestSuite.
-        The TestResult can be specified to capture the output, otherwise the results are output
-        as XML so that they can be formatted in some custom manner.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="result">
-        <xsd:annotation>
-          <xsd:documentation>Sets the JUnit TestResult used to capture the results of the tst</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="test">
-        <xsd:annotation>
-          <xsd:documentation>Sets the JUnit Test to run which could be an individual test or a TestSuite</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="listener">
-        <xsd:annotation>
-          <xsd:documentation>Sets the TestListener.to be used to format the output of running the unit test cases</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="fail">
-    <xsd:annotation>
-      <xsd:documentation>This tag causes a failure message. The message can either
-        be specified in the tags body or via the message attribute.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="message">
-        <xsd:annotation>
-          <xsd:documentation>Sets the failure message. If this attribute is not specified then the
-            body of this tag will be used instead.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="case">
-    <xsd:annotation>
-      <xsd:documentation>Represents a single test case in a test suite; this tag is analagous to
-        JUnit's TestCase class.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of this test case</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="assertThrows">
-    <xsd:annotation>
-      <xsd:documentation>
-        Runs its body and asserts that an exception is thrown by it.  If no
-        exception is thrown the tag fails.  By default all exceptions are caught.
-        If however
-
-        <code>expected</code>
-        was specified the body must throw
-        an exception of the given class, otherwise the assertion fails.  The
-        exception thrown by the body can also be of any subtype of the specified
-        exception class.  The optional
-
-        <code>var</code>
-        attribute can be specified if
-        the caught exception is to be exported to a variable.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="expected">
-        <xsd:annotation>
-          <xsd:documentation>
-            Sets the class name of exception expected to be thrown by the body.  The
-            class name must be fully qualified and can either be the expected
-            exception class itself or any supertype of it, but must be a subtype of
-
-
-            <code>java.lang.Throwable</code>
-            .
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to define for this expression.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="classLoader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the class loader to be used to load the exception type</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="">
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="assert">
     <xsd:annotation>
       <xsd:documentation>Performs an assertion that a given boolean expression, or XPath expression is
@@ -268,18 +56,23 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="assertFileNotFound">
+  <xsd:element name="suite">
     <xsd:annotation>
-      <xsd:documentation>Checks that a file cant be found.</xsd:documentation>
+      <xsd:documentation>Represents a collection of TestCases.. This tag is analagous to
+        JUnit's TestSuite class.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="file">
+      <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>The file to be tested. If this file exists, the test will pass.</xsd:documentation>
+          <xsd:documentation>Sets the name of the test suite whichi is exported</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of this test suite</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -294,7 +87,41 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="run">
+    <xsd:annotation>
+      <xsd:documentation>This tag will run the given Test which could be an individual TestCase or a TestSuite. The TestResult can be specified to capture the output, otherwise the results are output as XML so that they can be formatted in some custom manner.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="result">
+        <xsd:annotation>
+          <xsd:documentation>Sets the JUnit TestResult used to capture the results of the tst</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="test">
+        <xsd:annotation>
+          <xsd:documentation>Sets the JUnit Test to run which could be an individual test or a TestSuite</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="listener">
+        <xsd:annotation>
+          <xsd:documentation>Sets the TestListener.to be used to format the output of running the unit test cases</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="assertFileExists">
     <xsd:annotation>
       <xsd:documentation>Checks that a file exists, and if not, then the test will fail.</xsd:documentation>
@@ -320,7 +147,87 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="assertEquals">
+    <xsd:annotation>
+      <xsd:documentation>Compares an actual object against an expected object and if they are different then the test will fail.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="actual">
+        <xsd:annotation>
+          <xsd:documentation>Sets the actual value which will be compared against the expected value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="expected">
+        <xsd:annotation>
+          <xsd:documentation>Sets the expected value to be tested against</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="case">
+    <xsd:annotation>
+      <xsd:documentation>Represents a single test case in a test suite; this tag is analagous to
+        JUnit's TestCase class.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of this test case</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="assertFileNotFound">
+    <xsd:annotation>
+      <xsd:documentation>Checks that a file cant be found.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>The file to be tested. If this file exists, the test will pass.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="assertFileContains">
     <xsd:annotation>
       <xsd:documentation>Checks that a file exists, and if not, then the test will fail.</xsd:documentation>
@@ -352,25 +259,19 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="assertEquals">
+  <xsd:element name="fail">
     <xsd:annotation>
-      <xsd:documentation>Compares an actual object against an expected object and if they are different
-        then the test will fail.</xsd:documentation>
+      <xsd:documentation>This tag causes a failure message. The message can either
+        be specified in the tags body or via the message attribute.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="actual">
+      <xsd:attribute name="message">
         <xsd:annotation>
-          <xsd:documentation>Sets the actual value which will be compared against the
-            expected value.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="expected">
-        <xsd:annotation>
-          <xsd:documentation>Sets the expected value to be tested against</xsd:documentation>
+          <xsd:documentation>Sets the failure message. If this attribute is not specified then the
+            body of this tag will be used instead.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -385,5 +286,58 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="assertThrows">
+    <xsd:annotation>
+      <xsd:documentation>
+        Runs its body and asserts that an exception is thrown by it.  If no
+        exception is thrown the tag fails.  By default all exceptions are caught.
+        If however
 
+        <code>expected</code>
+        was specified the body must throw
+        an exception of the given class, otherwise the assertion fails.  The
+        exception thrown by the body can also be of any subtype of the specified
+        exception class.  The optional
+
+        <code>var</code>
+        attribute can be specified if
+        the caught exception is to be exported to a variable.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="expected">
+        <xsd:annotation>
+          <xsd:documentation>
+            Sets the class name of exception expected to be thrown by the body.  The
+            class name must be fully qualified and can either be the expected
+            exception class itself or any supertype of it, but must be a subtype of
+            <code>java.lang.Throwable</code>.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name to define for this expression.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="classLoader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the class loader to be used to load the exception type</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/junit.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/junit.xsd
@@ -1,62 +1,51 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:junit" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:junit" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>A collection of
-        <a href="http://www.junit.org">JUnit</a>tags for performing unit tests written in Jelly script.
+
+      <p>
+        A collection of
+
+        <a>JUnit</a>
+        tags for
+        performing unit tests written in Jelly script.
+
       </p>
-      <p>The &lt;suite&gt;tag allows a test suite to be created and then test cases can either be individually ran or the whole suite ran.</p>
-      <p>The &lt;case&gt;tag allows a single test case to be created as part of a suite.</p>
-      <p>The &lt;run&gt;tag can be used to run a given Test, TestCase or TestSuite</p>
-      <p>There is an example of these tags in action 
-        <a href="http://cvs.apache.org/viewcvs.cgi/jakarta-commons/jelly/jelly-tags/junit/src/test/org/apache/commons/jelly/tags/junit/suite.jelly?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup">here</a>
+
+
+
+      <p>
+        The &lt;suite&gt; tag allows a test suite to be created and then test cases can either
+        be individually ran or the whole suite ran.
       </p>
+
+
+      <p>
+        The &lt;case&gt; tag allows a single test case to be created as part of a suite.
+      </p>
+
+
+      <p>
+        The &lt;run&gt; tag can be used to run a given Test, TestCase or TestSuite
+      </p>
+
+
+
+      <p>
+        There is an example of these tags in action
+
+
+        <a>here</a>
+
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="assert">
-    <xsd:annotation>
-      <xsd:documentation>Performs an assertion that a given boolean expression, or XPath expression istrue. If the expression returns false then this test fails.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="test">
-        <xsd:annotation>
-          <xsd:documentation>Sets the boolean expression to evaluate. If this expression returns truethen the test succeeds otherwise if it returns false then the text willfail with the content of the tag being the error message.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="xpath">
-        <xsd:annotation>
-          <xsd:documentation>Sets the boolean XPath expression to evaluate. If this expression returns truethen the test succeeds otherwise if it returns false then the text willfail with the content of the tag being the error message.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="suite">
     <xsd:annotation>
-      <xsd:documentation>Represents a collection of TestCases.. This tag is analagous toJUnit's TestSuite class.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>Represents a collection of TestCases.. This tag is analagous to
+        JUnit's TestSuite class.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -77,11 +66,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -89,12 +73,12 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="run">
     <xsd:annotation>
-      <xsd:documentation>This tag will run the given Test which could be an individual TestCase or a TestSuite.The TestResult can be specified to capture the output, otherwise the results are outputas XML so that they can be formatted in some custom manner.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>This tag will run the given Test which could be an individual TestCase or a TestSuite.
+        The TestResult can be specified to capture the output, otherwise the results are output
+        as XML so that they can be formatted in some custom manner.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -102,31 +86,20 @@
       </xsd:sequence>
       <xsd:attribute name="result">
         <xsd:annotation>
-          <xsd:documentation>Sets the JUnit TestResult used to capture the results of the tst
-          <paramtag>result The TestResult to use</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the JUnit TestResult used to capture the results of the tst</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="test">
         <xsd:annotation>
-          <xsd:documentation>Sets the JUnit Test to run which could be an individual test or a TestSuite
-          <paramtag>test The test to run</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the JUnit Test to run which could be an individual test or a TestSuite</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="listener">
         <xsd:annotation>
-          <xsd:documentation>Sets the TestListener.to be used to format the output of running the unit test cases
-          <paramtag>listener The listener to set</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the TestListener.to be used to format the output of running the unit test cases</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -138,30 +111,23 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="assertFileExists">
+
+  <xsd:element name="fail">
     <xsd:annotation>
-      <xsd:documentation>Checks that a file exists, and if not, then the test will fail.
-        <authortag>&lt;a href="mailto:dion@apache.org"&gt;Dion Gillard&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>This tag causes a failure message. The message can either
+        be specified in the tags body or via the message attribute.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="file">
+      <xsd:attribute name="message">
         <xsd:annotation>
-          <xsd:documentation>The file to be tested. If this file exists, the test will pass.
-          <paramtag>aFile the file to test.</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the failure message. If this attribute is not specified then the
+            body of this tag will be used instead.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -173,50 +139,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="assertEquals">
-    <xsd:annotation>
-      <xsd:documentation>Compares an actual object against an expected object and if they are differentthen the test will fail.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="actual">
-        <xsd:annotation>
-          <xsd:documentation>Sets the actual value which will be compared against theexpected value.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="expected">
-        <xsd:annotation>
-          <xsd:documentation>Sets the expected value to be tested against</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="case">
     <xsd:annotation>
-      <xsd:documentation>Represents a single test case in a test suite; this tag is analagous toJUnit's TestCase class.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>Represents a single test case in a test suite; this tag is analagous to
+        JUnit's TestCase class.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -232,11 +159,6 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
       <xsd:attribute name="escapeText">
         <xsd:annotation>
           <xsd:documentation/>
@@ -244,119 +166,23 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="assertFileNotFound">
-    <xsd:annotation>
-      <xsd:documentation>Checks that a file cant be found.
-        <authortag>&lt;a href="mailto:dion@apache.org"&gt;Dion Gillard&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>The file to be tested. If this file exists, the test will pass.
-          <paramtag>aFile the file to test.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="assertFileContains">
-    <xsd:annotation>
-      <xsd:documentation>Checks that a file exists, and if not, then the test will fail.
-        <authortag>&lt;a href="mailto:dion@apache.org"&gt;Dion Gillard&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>The file to be tested. If this file exists, the test will pass.
-          <paramtag>aFile the file to test.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="match">
-        <xsd:annotation>
-          <xsd:documentation>The content to be checked for. If this text matches some partof the given file, the test will pass.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="fail">
-    <xsd:annotation>
-      <xsd:documentation>This tag causes a failure message. The message can eitherbe specified in the tags body or via the message attribute.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="message">
-        <xsd:annotation>
-          <xsd:documentation>Sets the failure message. If this attribute is not specified then thebody of this tag will be used instead.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="assertThrows">
     <xsd:annotation>
-      <xsd:documentation>Runs its body and asserts that an exception is thrown by it. If noexception is thrown the tag fails. By default all exceptions are caught.If however
-        <code>expected</code>was specified the body must throwan exception of the given class, otherwise the assertion fails. Theexception thrown by the body can also be of any subtype of the specifiedexception class. The optional
-        <code>var</code>attribute can be specified ifthe caught exception is to be exported to a variable.
+      <xsd:documentation>
+        Runs its body and asserts that an exception is thrown by it.  If no
+        exception is thrown the tag fails.  By default all exceptions are caught.
+        If however
+
+        <code>expected</code>
+        was specified the body must throw
+        an exception of the given class, otherwise the assertion fails.  The
+        exception thrown by the body can also be of any subtype of the specified
+        exception class.  The optional
+
+        <code>var</code>
+        attribute can be specified if
+        the caught exception is to be exported to a variable.
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
@@ -365,9 +191,15 @@
       </xsd:sequence>
       <xsd:attribute name="expected">
         <xsd:annotation>
-          <xsd:documentation>Sets the class name of exception expected to be thrown by the body. Theclass name must be fully qualified and can either be the expectedexception class itself or any supertype of it, but must be a subtype of
-          <code>java.lang.Throwable</code>.
-        </xsd:documentation>
+          <xsd:documentation>
+            Sets the class name of exception expected to be thrown by the body.  The
+            class name must be fully qualified and can either be the expected
+            exception class itself or any supertype of it, but must be a subtype of
+
+
+            <code>java.lang.Throwable</code>
+            .
+          </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="var">
@@ -385,7 +217,46 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="">
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="assert">
+    <xsd:annotation>
+      <xsd:documentation>Performs an assertion that a given boolean expression, or XPath expression is
+        true. If the expression returns false then this test fails.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="test">
+        <xsd:annotation>
+          <xsd:documentation>Sets the boolean expression to evaluate. If this expression returns true
+            then the test succeeds otherwise if it returns false then the text will
+            fail with the content of the tag being the error message.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="xpath">
+        <xsd:annotation>
+          <xsd:documentation>Sets the boolean XPath expression to evaluate. If this expression returns true
+            then the test succeeds otherwise if it returns false then the text will
+            fail with the content of the tag being the error message.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -397,4 +268,122 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="assertFileNotFound">
+    <xsd:annotation>
+      <xsd:documentation>Checks that a file cant be found.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>The file to be tested. If this file exists, the test will pass.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="assertFileExists">
+    <xsd:annotation>
+      <xsd:documentation>Checks that a file exists, and if not, then the test will fail.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>The file to be tested. If this file exists, the test will pass.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="assertFileContains">
+    <xsd:annotation>
+      <xsd:documentation>Checks that a file exists, and if not, then the test will fail.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>The file to be tested. If this file exists, the test will pass.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="match">
+        <xsd:annotation>
+          <xsd:documentation>The content to be checked for. If this text matches some part
+            of the given file, the test will pass.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="assertEquals">
+    <xsd:annotation>
+      <xsd:documentation>Compares an actual object against an expected object and if they are different
+        then the test will fail.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="actual">
+        <xsd:annotation>
+          <xsd:documentation>Sets the actual value which will be compared against the
+            expected value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="expected">
+        <xsd:annotation>
+          <xsd:documentation>Sets the expected value to be tested against</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/log.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/log.xsd
@@ -1,26 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:log" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:log" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>
-        Custom tags for generating textual logging information using
-
-
-        <a>commons-logging</a>
-
-        which will use either log4j, logkit or JDK1.4 logging
-        depending on the classpath and configuration.
-
+      <p>Custom tags for generating textual logging information using
+        <a href="http://commons.apache.org/logging/">commons-logging</a> which will use either log4j, logkit or JDK1.4 logging depending on the classpath and configuration.
       </p>
-
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="warn">
+  <xsd:element name="error">
     <xsd:annotation>
-      <xsd:documentation>A tag which generates WARN level logging statement using
-        the given category name.</xsd:documentation>
+      <xsd:documentation>A tag which generates ERROR level logging statement using the given category name.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -38,8 +27,7 @@
       </xsd:attribute>
       <xsd:attribute name="encode">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
-            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -54,7 +42,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="trace">
     <xsd:annotation>
       <xsd:documentation>A tag which generates TRACE level logging statement using
@@ -76,8 +63,7 @@
       </xsd:attribute>
       <xsd:attribute name="encode">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
-            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -92,15 +78,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="">
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="info">
     <xsd:annotation>
       <xsd:documentation>A tag which generates INFO level logging statement using
@@ -138,83 +115,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="fatal">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates FATAL level logging statement using
-        the given category name.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
-            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="error">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates ERROR level logging statement using
-        the given category name.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
-            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="debug">
     <xsd:annotation>
       <xsd:documentation>A tag which generates DEBUG level logging statement using
@@ -252,5 +152,78 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="fatal">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates FATAL level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="warn">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates WARN level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/log.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/log.xsd
@@ -1,233 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:log" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:log" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>Custom tags for generating textual logging information using
-        <a href="http://commons.apache.org/logging/">commons-logging</a> which will use either log4j, logkit or JDK1.4 loggingdepending on the classpath and configuration.
+
+      <p>
+        Custom tags for generating textual logging information using
+
+
+        <a>commons-logging</a>
+
+        which will use either log4j, logkit or JDK1.4 logging
+        depending on the classpath and configuration.
+
       </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="error">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates ERROR level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="trace">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates TRACE level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="info">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates INFO level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="debug">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates DEBUG level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="fatal">
-    <xsd:annotation>
-      <xsd:documentation>A tag which generates FATAL level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="log">
-        <xsd:annotation>
-          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encode">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="warn">
     <xsd:annotation>
-      <xsd:documentation>A tag which generates WARN level logging statement usingthe given category name.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which generates WARN level logging statement using
+        the given category name.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -245,15 +38,11 @@
       </xsd:attribute>
       <xsd:attribute name="encode">
         <xsd:annotation>
-          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt;and &gt;areencoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -265,4 +54,203 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="trace">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates TRACE level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="">
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="info">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates INFO level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="fatal">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates FATAL level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="error">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates ERROR level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="debug">
+    <xsd:annotation>
+      <xsd:documentation>A tag which generates DEBUG level logging statement using
+        the given category name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the logger to use</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="log">
+        <xsd:annotation>
+          <xsd:documentation>Sets the Log instance to use for logging.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encode">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether the body of the tag should be encoded as text (so that &lt; and &gt; are
+            encoded as &amp;lt; and &amp;gt;) or leave the text as XML which is the default.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
@@ -227,6 +227,33 @@
   </xsd:element>
   <xsd:element name="header">
     <xsd:annotation>
+      <xsd:documentation>Adds an HTTP header to the response. Same as "addHeader" which is prefered.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="name" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Header name.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Header value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="addHeader">
+    <xsd:annotation>
       <xsd:documentation>Adds an HTTP header to the response.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
@@ -1,16 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:stapler" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:stapler" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>Optional Jelly support, to write views in Jelly.</xsd:documentation>
   </xsd:annotation>
+
+  <xsd:element name="structuredMessageFormat">
+    <xsd:annotation>
+      <xsd:documentation>Format message from a resource, but by using a nested children as arguments, instead of just using expressions.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="key" use="required">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lineNumber">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="columnNumber">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="fileName">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="elementName">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="structuredMessageArgument">
+    <xsd:annotation>
+      <xsd:documentation>
+        Body is evaluated and is used as an argument for the surrounding
+
+        <head>
+
+          <structuredmessageformat/>
+
+        </head>
+        element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="statusCode">
     <xsd:annotation>
-      <xsd:documentation>Sets HTTP status code.
+      <xsd:documentation>
+        Sets HTTP status code.
+
 
 
         <p>
-          This is generally useful for programatically creating the error page.
-        </p>
+          This is generally useful for programatically creating the error page.</p>
+
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
@@ -31,16 +110,20 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="redirect">
+
+  <xsd:element name="setHeader">
     <xsd:annotation>
-      <xsd:documentation>Sends HTTP redirect.</xsd:documentation>
+      <xsd:documentation>Sets an HTTP header to the response.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
-      <xsd:attribute name="url" use="required">
+      <xsd:attribute name="name" use="required">
         <xsd:annotation>
-          <xsd:documentation>Sets the target URL to redirect to. This just gets passed
-            to org.kohsuke.stapler.StaplerResponse.sendRedirect2(String).
-          </xsd:documentation>
+          <xsd:documentation>Header name.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Header value.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -55,11 +138,35 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="redirect">
+    <xsd:annotation>
+      <xsd:documentation>Sends HTTP redirect.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="url" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Sets the target URL to redirect to. This just gets passed
+            to org.kohsuke.stapler.StaplerResponse.sendRedirect2(String).</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="parentScope">
     <xsd:annotation>
       <xsd:documentation>Executes the body in the parent scope.
-        This is useful for creating a 'local' scope.
-      </xsd:documentation>
+        This is useful for creating a 'local' scope.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -77,12 +184,12 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="out">
     <xsd:annotation>
       <xsd:documentation>Tag that outputs the specified value but with escaping,
         so that you can escape a portion even if the
-        org.apache.commons.jelly.XMLOutput is not escaping.
-      </xsd:documentation>
+        org.apache.commons.jelly.XMLOutput is not escaping.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:attribute name="value" use="required">
@@ -102,27 +209,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="once">
-    <xsd:annotation>
-      <xsd:documentation>Tag that only evaluates its body once during the entire request processing.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="nbsp">
     <xsd:annotation>
       <xsd:documentation>Writes out '&amp;nbsp;'.</xsd:documentation>
@@ -140,6 +227,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="isUserInRole">
     <xsd:annotation>
       <xsd:documentation/>
@@ -165,11 +253,15 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="include">
     <xsd:annotation>
       <xsd:documentation>Tag that includes views of the object.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
       <xsd:attribute name="page" use="required">
         <xsd:annotation>
           <xsd:documentation>Specifies the name of the JSP to be included.</xsd:documentation>
@@ -178,29 +270,39 @@
       <xsd:attribute name="it">
         <xsd:annotation>
           <xsd:documentation>Specifies the object for which JSP will be included.
-            Defaults to the "it" object in the current context.
-          </xsd:documentation>
+            Defaults to the "it" object in the current context.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="from">
         <xsd:annotation>
           <xsd:documentation>When loading the script, use the classloader from this object
-            to locate the script. Otherwise defaults to "it" object.
-          </xsd:documentation>
+            to locate the script. Otherwise defaults to "it" object.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="class">
+      <xsd:attribute name="clazz">
         <xsd:annotation>
           <xsd:documentation>When loading script, load from this class.
 
             By default this is "from.getClass()". This takes
             precedence over the org.kohsuke.stapler.jelly.IncludeTag.setFrom(Object) method.
-          </xsd:documentation>
+
+            This used to be called setClass, but that ended up causing
+            problems with new commons-beanutils restrictions via
+            ConvertingWrapDynaBean use in JellyBuilder.
+            org.kohsuke.stapler.jelly.StaplerTagLibrary uses org.kohsuke.stapler.jelly.AttributeNameRewritingTagScript
+            to ensure attempts to set class instead set clazz, and
+            that attempts to set clazz directly that way fail.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="class">
+        <xsd:annotation>
+          <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="optional">
         <xsd:annotation>
-          <xsd:documentation>If true, not finding the page is not an error.</xsd:documentation>
+          <xsd:documentation>If true, not finding the page is not an error.
+            (And in such a case, the body of the include tag is evaluated instead.)</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -215,6 +317,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="header">
     <xsd:annotation>
       <xsd:documentation>Adds an HTTP header to the response.</xsd:documentation>
@@ -242,22 +345,28 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="documentation">
+
+  <xsd:element name="findAncestor">
     <xsd:annotation>
-      <xsd:documentation>Documentation for a Jelly tag file.
-
-
-        <p>
-          This tag should be placed right inside the root element once,
-          to describe the tag and its attributes. Maven-stapler-plugin
-          picks up this tag and generate schemas and documentations.
-        </p>
-      </xsd:documentation>
+      <xsd:documentation>Finds the nearest tag (in the call stack) that has the given tag name,
+        and sets that as a variable.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Variable name to set the discovered org.apache.commons.jelly.Tag object.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="tag">
+        <xsd:annotation>
+          <xsd:documentation>QName of the tag to look for.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="namespaceContext">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
       <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
@@ -270,6 +379,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="doctype">
     <xsd:annotation>
       <xsd:documentation>Writes out DOCTYPE declaration.</xsd:documentation>
@@ -297,6 +407,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="copyStream">
     <xsd:annotation>
       <xsd:documentation>Copies a stream as text.</xsd:documentation>
@@ -334,6 +445,7 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="contentType">
     <xsd:annotation>
       <xsd:documentation>Set the HTTP Content-Type header of the page.</xsd:documentation>
@@ -356,11 +468,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
   <xsd:element name="compress">
     <xsd:annotation>
       <xsd:documentation>Outer-most wrapper tag to indicate that the gzip compression is desirable
-        for this output.
-      </xsd:documentation>
+        for this output.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -378,15 +490,77 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="bind">
+    <xsd:annotation>
+      <xsd:documentation>
+        Binds a server-side object to client side so that JavaScript can call into server.
+        This tag evaluates to a
+
+        <head>
+
+          <script/>
+
+        </head>
+        tag.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>
+            JavaScript variable name to set the proxy to.
+
+
+            <p>
+              This name can be arbitrary left hand side expression,
+              such as "a[0]" or "a.b.c".
+
+              If this value is unspecified, the tag generates a JavaScript expression to create a proxy.</p>
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value" use="required">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="attribute">
     <xsd:annotation>
-      <xsd:documentation>Documentation for an attribute of a Jelly tag file.
+      <xsd:documentation>
+        Documentation for an attribute of a Jelly tag file.
+
 
 
         <p>
-          This tag should be placed right inside</p>org.kohsuke.stapler.jelly.DocumentationTag
+          This tag should be placed right inside </p>
+
+        <head>
+
+          <documentation/>
+
+        </head>
         to describe attributes of a tag. The body would describe
         the meaning of an attribute in a natural language.
+        The description text can also use
+
+
+        <a>Textile markup</a>
+
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
@@ -400,28 +574,28 @@
       </xsd:attribute>
       <xsd:attribute name="use">
         <xsd:annotation>
-          <xsd:documentation>If the attribute is required, specify use="required".
+          <xsd:documentation>
+            If the attribute is required, specify use="required".
             (This is modeled after XML Schema attribute declaration.)
 
 
+
             <p>
-              By default, use="optional" is assumed.
-            </p>
+              By default, use="optional" is assumed.</p>
+
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="type">
         <xsd:annotation>
           <xsd:documentation>If it makes sense, describe the Java type that the attribute
-            expects as values.
-          </xsd:documentation>
+            expects as values.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="deprecated">
         <xsd:annotation>
           <xsd:documentation>If the attribute is deprecated, set to true.
-            Use of the deprecated attribute will cause a warning.
-          </xsd:documentation>
+            Use of the deprecated attribute will cause a warning.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="since">
@@ -441,15 +615,32 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="adjunct">
+
+  <xsd:element name="attributeConstraints">
     <xsd:annotation>
-      <xsd:documentation>Writes out links to adjunct CSS and JavaScript, if not done so already.
+      <xsd:documentation>
+        DTD-like expression that specifies the constraints on attribute appearances.
+
+
+
+        <p>
+          This tag should be placed right inside </p>
+
+        <head>
+
+          <documentation/>
+
+        </head>
+        to describe attributes of a tag.
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
-      <xsd:attribute name="includes" use="required">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="expr" use="required">
         <xsd:annotation>
-          <xsd:documentation>Comma-separated adjunct names.</xsd:documentation>
+          <xsd:documentation>Constraint expression.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -464,4 +655,34 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="adjunct">
+    <xsd:annotation>
+      <xsd:documentation>Writes out links to adjunct CSS and JavaScript, if not done so already.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="includes">
+        <xsd:annotation>
+          <xsd:documentation>Comma-separated adjunct names.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="assumes">
+        <xsd:annotation>
+          <xsd:documentation>Comma-separated adjunct names that are externally included in the page
+            and should be suppressed.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
@@ -1,95 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:stapler" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:stapler" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>Optional Jelly support, to write views in Jelly.</xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="structuredMessageFormat">
-    <xsd:annotation>
-      <xsd:documentation>Format message from a resource, but by using a nested children as arguments, instead of just using expressions.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="key" use="required">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="lineNumber">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="columnNumber">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="fileName">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="elementName">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="structuredMessageArgument">
-    <xsd:annotation>
-      <xsd:documentation>
-        Body is evaluated and is used as an argument for the surrounding
-
-        <head>
-
-          <structuredmessageformat/>
-
-        </head>
-        element.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="statusCode">
     <xsd:annotation>
-      <xsd:documentation>
-        Sets HTTP status code.
-
+      <xsd:documentation>Sets HTTP status code.
 
 
         <p>
-          This is generally useful for programatically creating the error page.</p>
-
+          This is generally useful for programatically creating the error page.
+        </p>
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
@@ -110,35 +31,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="setHeader">
-    <xsd:annotation>
-      <xsd:documentation>Sets an HTTP header to the response.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:attribute name="name" use="required">
-        <xsd:annotation>
-          <xsd:documentation>Header name.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="value" use="required">
-        <xsd:annotation>
-          <xsd:documentation>Header value.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="redirect">
     <xsd:annotation>
       <xsd:documentation>Sends HTTP redirect.</xsd:documentation>
@@ -162,7 +54,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="parentScope">
     <xsd:annotation>
       <xsd:documentation>Executes the body in the parent scope.
@@ -184,7 +75,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="out">
     <xsd:annotation>
       <xsd:documentation>Tag that outputs the specified value but with escaping,
@@ -209,7 +99,27 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="once">
+    <xsd:annotation>
+      <xsd:documentation>Tag that only evaluates its body once during the entire request processing.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="nbsp">
     <xsd:annotation>
       <xsd:documentation>Writes out '&amp;nbsp;'.</xsd:documentation>
@@ -227,7 +137,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="isUserInRole">
     <xsd:annotation>
       <xsd:documentation/>
@@ -253,7 +162,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="include">
     <xsd:annotation>
       <xsd:documentation>Tag that includes views of the object.</xsd:documentation>
@@ -317,7 +225,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="header">
     <xsd:annotation>
       <xsd:documentation>Adds an HTTP header to the response.</xsd:documentation>
@@ -345,28 +252,22 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="findAncestor">
+  <xsd:element name="documentation">
     <xsd:annotation>
-      <xsd:documentation>Finds the nearest tag (in the call stack) that has the given tag name,
-        and sets that as a variable.</xsd:documentation>
+      <xsd:documentation>Documentation for a Jelly tag file.
+
+
+        <p>
+          This tag should be placed right inside the root element once,
+          to describe the tag and its attributes. Maven-stapler-plugin
+          picks up this tag and generate schemas and documentations.
+        </p>
+      </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Variable name to set the discovered org.apache.commons.jelly.Tag object.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tag">
-        <xsd:annotation>
-          <xsd:documentation>QName of the tag to look for.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="namespaceContext">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
       <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
@@ -379,7 +280,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="doctype">
     <xsd:annotation>
       <xsd:documentation>Writes out DOCTYPE declaration.</xsd:documentation>
@@ -407,7 +307,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="copyStream">
     <xsd:annotation>
       <xsd:documentation>Copies a stream as text.</xsd:documentation>
@@ -445,7 +344,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="contentType">
     <xsd:annotation>
       <xsd:documentation>Set the HTTP Content-Type header of the page.</xsd:documentation>
@@ -468,7 +366,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="compress">
     <xsd:annotation>
       <xsd:documentation>Outer-most wrapper tag to indicate that the gzip compression is desirable
@@ -490,7 +387,238 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="attribute">
+    <xsd:annotation>
+      <xsd:documentation>Documentation for an attribute of a Jelly tag file.
 
+
+        <p>
+          This tag should be placed right inside </p>
+
+        <head>
+
+          <documentation/>
+
+        </head>
+        to describe attributes of a tag. The body would describe
+        the meaning of an attribute in a natural language.
+        The description text can also use
+
+
+        <a>Textile markup</a>
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Name of the attribute.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="use">
+        <xsd:annotation>
+          <xsd:documentation>If the attribute is required, specify use="required".
+            (This is modeled after XML Schema attribute declaration.)
+
+
+            <p>
+              By default, use="optional" is assumed.</p>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="type">
+        <xsd:annotation>
+          <xsd:documentation>If it makes sense, describe the Java type that the attribute
+            expects as values.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="deprecated">
+        <xsd:annotation>
+          <xsd:documentation>If the attribute is deprecated, set to true.
+            Use of the deprecated attribute will cause a warning.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="since">
+        <xsd:annotation>
+          <xsd:documentation>Used to track when the attribute was added to the API surface.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="adjunct">
+    <xsd:annotation>
+      <xsd:documentation>Writes out links to adjunct CSS and JavaScript, if not done so already.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="includes">
+        <xsd:annotation>
+          <xsd:documentation>Comma-separated adjunct names.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="assumes">
+        <xsd:annotation>
+          <xsd:documentation>Comma-separated adjunct names that are externally included in the page
+            and should be suppressed.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="attributeConstraints">
+    <xsd:annotation>
+      <xsd:documentation>
+        DTD-like expression that specifies the constraints on attribute appearances.
+        <p>
+          This tag should be placed right inside &lt;st:documentation&gt;
+
+        to describe attributes of a tag.
+        </p>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="expr" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Constraint expression.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="structuredMessageFormat">
+    <xsd:annotation>
+      <xsd:documentation>Format message from a resource, but by using a nested children as arguments, instead of just using expressions.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="key" use="required">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lineNumber">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="columnNumber">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="fileName">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="elementName">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="structuredMessageArgument">
+    <xsd:annotation>
+      <xsd:documentation>
+        Body is evaluated and is used as an argument for the surrounding
+
+        <head>
+
+          <structuredmessageformat/>
+
+        </head>
+        element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="setHeader">
+    <xsd:annotation>
+      <xsd:documentation>Sets an HTTP header to the response.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="name" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Header name.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value" use="required">
+        <xsd:annotation>
+          <xsd:documentation>Header value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="bind">
     <xsd:annotation>
       <xsd:documentation>
@@ -538,151 +666,4 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="attribute">
-    <xsd:annotation>
-      <xsd:documentation>
-        Documentation for an attribute of a Jelly tag file.
-
-
-
-        <p>
-          This tag should be placed right inside </p>
-
-        <head>
-
-          <documentation/>
-
-        </head>
-        to describe attributes of a tag. The body would describe
-        the meaning of an attribute in a natural language.
-        The description text can also use
-
-
-        <a>Textile markup</a>
-
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name" use="required">
-        <xsd:annotation>
-          <xsd:documentation>Name of the attribute.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="use">
-        <xsd:annotation>
-          <xsd:documentation>
-            If the attribute is required, specify use="required".
-            (This is modeled after XML Schema attribute declaration.)
-
-
-
-            <p>
-              By default, use="optional" is assumed.</p>
-
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="type">
-        <xsd:annotation>
-          <xsd:documentation>If it makes sense, describe the Java type that the attribute
-            expects as values.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="deprecated">
-        <xsd:annotation>
-          <xsd:documentation>If the attribute is deprecated, set to true.
-            Use of the deprecated attribute will cause a warning.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="since">
-        <xsd:annotation>
-          <xsd:documentation>Used to track when the attribute was added to the API surface.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="attributeConstraints">
-    <xsd:annotation>
-      <xsd:documentation>
-        DTD-like expression that specifies the constraints on attribute appearances.
-
-
-
-        <p>
-          This tag should be placed right inside </p>
-
-        <head>
-
-          <documentation/>
-
-        </head>
-        to describe attributes of a tag.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="expr" use="required">
-        <xsd:annotation>
-          <xsd:documentation>Constraint expression.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="adjunct">
-    <xsd:annotation>
-      <xsd:documentation>Writes out links to adjunct CSS and JavaScript, if not done so already.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:attribute name="includes">
-        <xsd:annotation>
-          <xsd:documentation>Comma-separated adjunct names.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="assumes">
-        <xsd:annotation>
-          <xsd:documentation>Comma-separated adjunct names that are externally included in the page
-            and should be suppressed.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/stapler.xsd
@@ -693,4 +693,18 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="getOutput">
+    <xsd:annotation>
+      <xsd:documentation>
+        Adds org.apache.commons.jelly.XMLOutput to the context.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/util.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/util.xsd
@@ -1,333 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:util" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:util" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>A number of utility tags such as for tokenizing Strings.</p>
+
+      <p>A number of utility tags such as for tokenizing Strings.
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="sleep">
-    <xsd:annotation>
-      <xsd:documentation>A tag which sleeps for a given amount of time.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="millis">
-        <xsd:annotation>
-          <xsd:documentation>Sets the amount of time that this thread should sleep for in milliseconds.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="file">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a java.io.Filefrom a given name.
-        <authortag>&lt;a href="mailto:dion@apache.org"&gt;dIon Gillard&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Name of the file to be placed into the context
-          <paramtag>name The fileName to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Name of the variable to contain the file
-          <paramtag>var The var to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="loadText">
-    <xsd:annotation>
-      <xsd:documentation>A tag which loads text from a file or URI into a Jelly variable.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which will be exported with the text value of thegiven file.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Sets the file to be parsed as text</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encoding">
-        <xsd:annotation>
-          <xsd:documentation>Sets the encoding to use to read the file</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the uri to be parsed as text.This can be an absolute URL or a relative or absolute URIfrom this Jelly script or the root context.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="replace">
-    <xsd:annotation>
-      <xsd:documentation>A tag that replaces occurrences of a character or string in its body or(or value) and places the result into the context
-        <authortag>dion</authortag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="newChar">
-        <xsd:annotation>
-          <xsd:documentation>Sets the newChar.
-          <paramtag>newChar The newChar to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="oldChar">
-        <xsd:annotation>
-          <xsd:documentation>Sets the oldChar.
-          <paramtag>oldChar The oldChar to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="new">
-        <xsd:annotation>
-          <xsd:documentation>Sets the newString.
-          <paramtag>newString The newString to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="old">
-        <xsd:annotation>
-          <xsd:documentation>Sets the oldString.
-          <paramtag>oldString The oldString to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Sets the value.
-          <paramtag>value The value to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the var.
-          <paramtag>var The var to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="sort">
-    <xsd:annotation>
-      <xsd:documentation/>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="items">
-        <xsd:annotation>
-          <xsd:documentation>Set the items to be sorted
-          <paramtag>newItems some collection</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>The variable to hold the sorted collection.
-          <paramtag>newVar the name of the variable.</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="property">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="properties">
-    <xsd:annotation>
-      <xsd:documentation>A tag which loads a properties file from a given file name or URIwhich are loaded into the current context.
-        <authortag>Jim Birchfield</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Sets the file name to be used to load the properties file.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the URI of the properties file to use. This can be a full URL or a relative URIor an absolute URI to the root context of this JellyContext.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>If this is defined then a Properties object containing all theproperties will be created and exported, otherwise the current variablescope will be set to the value of the properties.
-          <paramtag>var The var to set</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="available">
-    <xsd:annotation>
-      <xsd:documentation>A tag which evaluates its body if the given file is available.The file can be specified via a File object or via a relative or absoluteURI from the current Jelly script.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Sets the file to use to test whether it exists or not.
-          <paramtag>file the file to test for</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the URI to use to test for availability.The URI can be a full file based URL or a relative URIor an absolute URI from the root context.
-          <paramtag>uri the URI of the file to test</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="tagLib">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="tokenize">
     <xsd:annotation>
       <xsd:documentation/>
@@ -351,7 +32,38 @@
           <xsd:documentation/>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="tagLib">
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="sort">
+    <xsd:annotation>
+      <xsd:documentation/>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="items">
+        <xsd:annotation>
+          <xsd:documentation>Set the items to be sorted</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>The variable to hold the sorted collection.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="property">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
         <xsd:annotation>
           <xsd:documentation/>
         </xsd:annotation>
@@ -363,4 +75,233 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="sleep">
+    <xsd:annotation>
+      <xsd:documentation>A tag which sleeps for a given amount of time.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="millis">
+        <xsd:annotation>
+          <xsd:documentation>Sets the amount of time that this thread should sleep for in milliseconds.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="replace">
+    <xsd:annotation>
+      <xsd:documentation>A tag that replaces occurrences of a character or string in its body or
+        (or value) and places the result into the context</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="newChar">
+        <xsd:annotation>
+          <xsd:documentation>Sets the newChar.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="oldChar">
+        <xsd:annotation>
+          <xsd:documentation>Sets the oldChar.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="new">
+        <xsd:annotation>
+          <xsd:documentation>Sets the newString.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="old">
+        <xsd:annotation>
+          <xsd:documentation>Sets the oldString.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Sets the value.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the var.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="properties">
+    <xsd:annotation>
+      <xsd:documentation>A tag which loads a properties file from a given file name or URI
+        which are loaded into the current context.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file name to be used to load the properties file.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the URI of the properties file to use. This can be a full URL or a relative URI
+            or an absolute URI to the root context of this JellyContext.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>If this is defined then a Properties object containing all the
+            properties will be created and exported, otherwise the current variable
+            scope will be set to the value of the properties.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="loadText">
+    <xsd:annotation>
+      <xsd:documentation>A tag which loads text from a file or URI into a Jelly variable.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which will be exported with the text value of the
+            given file.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file to be parsed as text</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encoding">
+        <xsd:annotation>
+          <xsd:documentation>Sets the encoding to use to read the file</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the uri to be parsed as text.
+            This can be an absolute URL or a relative or absolute URI
+            from this Jelly script or the root context.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="file">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a java.io.File from a given name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Name of the file to be placed into the context</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Name of the variable to contain the file</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="available">
+    <xsd:annotation>
+      <xsd:documentation>A tag which evaluates its body if the given file is available.
+        The file can be specified via a File object or via a relative or absolute
+        URI from the current Jelly script.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file to use to test whether it exists or not.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the URI to use to test for availability.
+            The URI can be a full file based URL or a relative URI
+            or an absolute URI from the root context.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/util.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/util.xsd
@@ -1,81 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:util" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:util" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>A number of utility tags such as for tokenizing Strings.
-      </p>
-
+      <p>A number of utility tags such as for tokenizing Strings.</p>
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="tokenize">
-    <xsd:annotation>
-      <xsd:documentation/>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>The variable name to hold the list of tokens</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="delim">
-        <xsd:annotation>
-          <xsd:documentation>the delimiter that separates the tokens</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="sort">
-    <xsd:annotation>
-      <xsd:documentation/>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="items">
-        <xsd:annotation>
-          <xsd:documentation>Set the items to be sorted</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>The variable to hold the sorted collection.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="property">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="sleep">
     <xsd:annotation>
       <xsd:documentation>A tag which sleeps for a given amount of time.</xsd:documentation>
@@ -101,7 +30,79 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="file">
+    <xsd:annotation>
+      <xsd:documentation>A tag which creates a java.io.File from a given name.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Name of the file to be placed into the context</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Name of the variable to contain the file</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="loadText">
+    <xsd:annotation>
+      <xsd:documentation>A tag which loads text from a file or URI into a Jelly variable.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the variable which will be exported with the text value of the
+            given file.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="file">
+        <xsd:annotation>
+          <xsd:documentation>Sets the file to be parsed as text</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="encoding">
+        <xsd:annotation>
+          <xsd:documentation>Sets the encoding to use to read the file</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="uri">
+        <xsd:annotation>
+          <xsd:documentation>Sets the uri to be parsed as text.
+            This can be an absolute URL or a relative or absolute URI
+            from this Jelly script or the root context.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="replace">
     <xsd:annotation>
       <xsd:documentation>A tag that replaces occurrences of a character or string in its body or
@@ -153,7 +154,41 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="sort">
+    <xsd:annotation>
+      <xsd:documentation/>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="items">
+        <xsd:annotation>
+          <xsd:documentation>Set the items to be sorted</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>The variable to hold the sorted collection.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="property">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="properties">
     <xsd:annotation>
       <xsd:documentation>A tag which loads a properties file from a given file name or URI
@@ -193,82 +228,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="loadText">
-    <xsd:annotation>
-      <xsd:documentation>A tag which loads text from a file or URI into a Jelly variable.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the variable which will be exported with the text value of the
-            given file.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="file">
-        <xsd:annotation>
-          <xsd:documentation>Sets the file to be parsed as text</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="encoding">
-        <xsd:annotation>
-          <xsd:documentation>Sets the encoding to use to read the file</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="uri">
-        <xsd:annotation>
-          <xsd:documentation>Sets the uri to be parsed as text.
-            This can be an absolute URL or a relative or absolute URI
-            from this Jelly script or the root context.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="file">
-    <xsd:annotation>
-      <xsd:documentation>A tag which creates a java.io.File from a given name.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Name of the file to be placed into the context</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Name of the variable to contain the file</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="available">
     <xsd:annotation>
       <xsd:documentation>A tag which evaluates its body if the given file is available.
@@ -303,5 +262,34 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="tokenize">
+    <xsd:annotation>
+      <xsd:documentation/>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>The variable name to hold the list of tokens</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="delim">
+        <xsd:annotation>
+          <xsd:documentation>the delimiter that separates the tokens</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/xml.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/xml.xsd
@@ -1,108 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:xml" elementFormDefault="qualified">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:xml" elementFormDefault="qualified">
   <xsd:annotation>
     <xsd:documentation>
-
-      <p>The XML Tags from the JSTL
-      </p>
-
+      <p>The XML Tags from the JSTL</p>
     </xsd:documentation>
   </xsd:annotation>
-
-  <xsd:element name="transform">
-    <xsd:annotation>
-      <xsd:documentation>A tag which parses some XML, applies an xslt transform to it
-        and defines a variable with the transformed Document.
-        The XML can either be specified as its body or can be passed in via the
-        xml property which can be a Reader, InputStream, URL or String URI.
-
-        The XSL can be passed in via the
-        xslt property which can be a Reader, InputStream, URL or String URI.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="xslt">
-        <xsd:annotation>
-          <xsd:documentation>Sets the source of the XSL which is either a String URI, Reader or
-            InputStream</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="xml">
-        <xsd:annotation>
-          <xsd:documentation>Sets the source of the XML which is either a String URI, a File, Reader or InputStream</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="validate">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether XML validation is enabled or disabled</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="SAXReader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the SAXReader used for parsing</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="sort">
-    <xsd:annotation>
-      <xsd:documentation>A tag that can sort a list of xml nodes via an xpath expression.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="list">
-        <xsd:annotation>
-          <xsd:documentation>Set the list to sort.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="sort">
-        <xsd:annotation>
-          <xsd:documentation>Sets the xpath expression to use to sort selected nodes.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="descending">
-        <xsd:annotation>
-          <xsd:documentation>Set whether to sort ascending or descending.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="set">
     <xsd:annotation>
       <xsd:documentation>A tag which defines a variable from an XPath expression.
@@ -177,24 +79,28 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="replaceNamespace">
+  <xsd:element name="element">
     <xsd:annotation>
-      <xsd:documentation>Replace namespace is a filter to change the namespace of any
-        elemement attribute passing through it.</xsd:documentation>
+      <xsd:documentation>
+        A tag to produce an XML element which can contain other attributes
+        or elements like the
+
+        <code>&lt;xsl:element&gt;</code>
+        tag.
+      </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="fromURI">
+      <xsd:attribute name="name">
         <xsd:annotation>
-          <xsd:documentation>Sets the source namespace URI to replace.</xsd:documentation>
+          <xsd:documentation>Sets the qualified name of the element</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="toURI">
+      <xsd:attribute name="URI">
         <xsd:annotation>
-          <xsd:documentation>Sets the destination namespace URI to replace.</xsd:documentation>
+          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -209,15 +115,120 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="">
+  <xsd:element name="copyOf">
+    <xsd:annotation>
+      <xsd:documentation>A tag which performs a copy-of operation like the XSLT tag</xsd:documentation>
+    </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lexical">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="comment">
+    <xsd:annotation>
+      <xsd:documentation>A tag which outputs a comment to the underlying XMLOutput based on the
+        contents of its body.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the comment text. If no text is specified then the body of the tag
+            is used instead.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="transform">
+    <xsd:annotation>
+      <xsd:documentation>A tag which parses some XML, applies an xslt transform to it
+        and defines a variable with the transformed Document.
+        The XML can either be specified as its body or can be passed in via the
+        xml property which can be a Reader, InputStream, URL or String URI.
 
+        The XSL can be passed in via the
+        xslt property which can be a Reader, InputStream, URL or String URI.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="xslt">
+        <xsd:annotation>
+          <xsd:documentation>Sets the source of the XSL which is either a String URI, Reader or
+            InputStream</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="xml">
+        <xsd:annotation>
+          <xsd:documentation>Sets the source of the XML which is either a String URI, a File, Reader or InputStream</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="validate">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether XML validation is enabled or disabled</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SAXReader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the SAXReader used for parsing</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="parse">
     <xsd:annotation>
       <xsd:documentation>A tag which parses some XML and defines a variable with the parsed Document.
@@ -265,7 +276,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
   <xsd:element name="param">
     <xsd:annotation>
       <xsd:documentation>Sets a parameter in the parent transform tag</xsd:documentation>
@@ -296,19 +306,23 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="if">
+  <xsd:element name="replaceNamespace">
     <xsd:annotation>
-      <xsd:documentation>Evaluates the XPath expression to be a boolean and only evaluates the body
-        if the expression is true.</xsd:documentation>
+      <xsd:documentation>Replace namespace is a filter to change the namespace of any
+        elemement attribute passing through it.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="select">
+      <xsd:attribute name="fromURI">
         <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+          <xsd:documentation>Sets the source namespace URI to replace.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="toURI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the destination namespace URI to replace.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -323,7 +337,108 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element name="copy">
+    <xsd:annotation>
+      <xsd:documentation>A tag which performs a copy operation like the XSLT tag,
+        performing a shallow copy of the element and its attributes but no content.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lexical">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="sort">
+    <xsd:annotation>
+      <xsd:documentation>A tag that can sort a list of xml nodes via an xpath expression.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="list">
+        <xsd:annotation>
+          <xsd:documentation>Set the list to sort.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="sort">
+        <xsd:annotation>
+          <xsd:documentation>Sets the xpath expression to use to sort selected nodes.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="descending">
+        <xsd:annotation>
+          <xsd:documentation>Set whether to sort ascending or descending.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="attribute">
+    <xsd:annotation>
+      <xsd:documentation>
+        Adds an XML attribute to the parent element tag like
+        the
 
+        <code>&lt;xsl:attribute&gt;</code>
+        tag.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="URI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="forEach">
     <xsd:annotation>
       <xsd:documentation>A tag which performs an iteration over the results of an XPath expression</xsd:documentation>
@@ -364,7 +479,32 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
+  <xsd:element name="if">
+    <xsd:annotation>
+      <xsd:documentation>Evaluates the XPath expression to be a boolean and only evaluates the body
+        if the expression is true.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="expr">
     <xsd:annotation>
       <xsd:documentation>A tag which performs a string XPath expression; similar to &lt;xsl:value-of&gt;
@@ -391,44 +531,6 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="element">
-    <xsd:annotation>
-      <xsd:documentation>
-        A tag to produce an XML element which can contain other attributes
-        or elements like the
-
-        <code>&lt;xsl:element&gt;</code>
-        tag.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the qualified name of the element</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="URI">
-        <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
   <xsd:element name="doctype">
     <xsd:annotation>
       <xsd:documentation>A tag which outputs a DOCTYPE declaration to the current XML output pipe.
@@ -466,133 +568,4 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-
-  <xsd:element name="copy">
-    <xsd:annotation>
-      <xsd:documentation>A tag which performs a copy operation like the XSLT tag,
-        performing a shallow copy of the element and its attributes but no content.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="lexical">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="copyOf">
-    <xsd:annotation>
-      <xsd:documentation>A tag which performs a copy-of operation like the XSLT tag</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="lexical">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="comment">
-    <xsd:annotation>
-      <xsd:documentation>A tag which outputs a comment to the underlying XMLOutput based on the
-        contents of its body.</xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the comment text. If no text is specified then the body of the tag
-            is used instead.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
-  <xsd:element name="attribute">
-    <xsd:annotation>
-      <xsd:documentation>
-        Adds an XML attribute to the parent element tag like
-        the
-
-        <code>&lt;xsl:attribute&gt;</code>
-        tag.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="URI">
-        <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-
 </xsd:schema>

--- a/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/xml.xsd
+++ b/src/main/resources/org/kohsuke/stapler/idea/resources/schemas/xml.xsd
@@ -1,174 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:xml" elementFormDefault="qualified">
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="jelly:xml" elementFormDefault="qualified">
+
   <xsd:annotation>
     <xsd:documentation>
-      <p>The XML Tags from the JSTL</p>
+
+      <p>The XML Tags from the JSTL
+      </p>
+
     </xsd:documentation>
   </xsd:annotation>
-  <xsd:element name="set">
-    <xsd:annotation>
-      <xsd:documentation>A tag which defines a variable from an XPath expression.This function creates a variable of type java.util.Listor org.dom4j.Node(for example org.dom4j.Elementor org.dom4j.Attribute).Thus, the variable created from xml:set can beused from the other xml library functions.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name to define for this expression</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="single">
-        <xsd:annotation>
-          <xsd:documentation>If set to true will only take the first element matching.It then guarantees that the result is of type org.dom4j.Nodethereby making sure that, for example,when an element is selected, one can directly call such methodsas setAttribute.
-          <br/> If set to false, guarantees that a list is returned.If set to false, guarantees that a list is returned.
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="asString">
-        <xsd:annotation>
-          <xsd:documentation>If set to true, will ensure that the (XPath) text-valueof the selected node is taken instead of the nodeitself.This ensures that, thereafter, string manipulationscan be performed on the result.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="delim">
-        <xsd:annotation>
-          <xsd:documentation>If set, returns a string delimited by this delimiter.Implies
-          <code>asString</code>to be true.
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="sort">
-        <xsd:annotation>
-          <xsd:documentation>Sets the xpath expression to use to sort selected nodes.Ignored if single is true.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="descending">
-        <xsd:annotation>
-          <xsd:documentation>Set whether to sort ascending or descending.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="element">
-    <xsd:annotation>
-      <xsd:documentation>A tag to produce an XML element which can contain other attributesor elements like the
-        <code>&lt;xsl:element&gt;</code>tag.
-        <authortag>James Strachan</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the qualified name of the element</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="URI">
-        <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="copyOf">
-    <xsd:annotation>
-      <xsd:documentation>A tag which performs a copy-of operation like the XSLT tag
-        <authortag>James Strachan</authortag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="lexical">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="comment">
-    <xsd:annotation>
-      <xsd:documentation>A tag which outputs a comment to the underlying XMLOutput based on thecontents of its body.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the comment text. If no text is specified then the body of the tagis used instead.
-          <paramtag>text The comment text to use</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="transform">
     <xsd:annotation>
-      <xsd:documentation>A tag which parses some XML, applies an xslt transform to itand defines a variable with the transformed Document.The XML can either be specified as its body or can be passed in via thexml property which can be a Reader, InputStream, URL or String URI.The XSL can be passed in via thexslt property which can be a Reader, InputStream, URL or String URI.
-        <authortag>Robert Leftwich</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which parses some XML, applies an xslt transform to it
+        and defines a variable with the transformed Document.
+        The XML can either be specified as its body or can be passed in via the
+        xml property which can be a Reader, InputStream, URL or String URI.
+
+        The XSL can be passed in via the
+        xslt property which can be a Reader, InputStream, URL or String URI.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -176,9 +25,8 @@
       </xsd:sequence>
       <xsd:attribute name="xslt">
         <xsd:annotation>
-          <xsd:documentation>Sets the source of the XSL which is either a String URI, Reader orInputStream
-          <paramtag>xslt The source of the xslt</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the source of the XSL which is either a String URI, Reader or
+            InputStream</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="xml">
@@ -198,9 +46,7 @@
       </xsd:attribute>
       <xsd:attribute name="text">
         <xsd:annotation>
-          <xsd:documentation>Sets the text to be parsed by this parser
-          <paramtag>text The text to be parsed by this parser</paramtag>
-        </xsd:documentation>
+          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="SAXReader">
@@ -220,159 +66,10 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="parse">
-    <xsd:annotation>
-      <xsd:documentation>A tag which parses some XML and defines a variable with the parsed Document.The XML can either be specified as its body or can be passed in via thexml property which can be a Reader, InputStream, URL or String URI.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="xml">
-        <xsd:annotation>
-          <xsd:documentation>Sets the source of the XML which is either a String URI, a File, Reader or InputStream</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="validate">
-        <xsd:annotation>
-          <xsd:documentation>Sets whether XML validation is enabled or disabled</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="var">
-        <xsd:annotation>
-          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="text">
-        <xsd:annotation>
-          <xsd:documentation>Sets the text to be parsed by this parser
-          <paramtag>text The text to be parsed by this parser</paramtag>
-        </xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="SAXReader">
-        <xsd:annotation>
-          <xsd:documentation>Sets the SAXReader used for parsing</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="param">
-    <xsd:annotation>
-      <xsd:documentation>Sets a parameter in the parent transform tag
-        <authortag>Robert Leftwich</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="name">
-        <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="value">
-        <xsd:annotation>
-          <xsd:documentation>Sets the value of the attribute</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="replaceNamespace">
-    <xsd:annotation>
-      <xsd:documentation>Replace namespace is a filter to change the namespace of anyelemement attribute passing through it.
-        <authortag>Diogo Quintela &lt;dquintela@gmail.com&gt;</authortag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="fromURI">
-        <xsd:annotation>
-          <xsd:documentation>Sets the source namespace URI to replace.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="toURI">
-        <xsd:annotation>
-          <xsd:documentation>Sets the destination namespace URI to replace.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="copy">
-    <xsd:annotation>
-      <xsd:documentation>A tag which performs a copy operation like the XSLT tag,performing a shallow copy of the element and its attributes but no content.
-        <authortag>James Strachan</authortag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="lexical">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="sort">
     <xsd:annotation>
-      <xsd:documentation>A tag that can sort a list of xml nodes via an xpath expression.
-        <authortag>&lt;a href="mailto:jason@jhorman.org"&gt;Jason Horman&lt;/a&gt;</authortag>
-        <versiontag>$Id: xml.xsd 847 2009-01-06 04:57:19Z kohsuke $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag that can sort a list of xml nodes via an xpath expression.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -405,26 +102,67 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="attribute">
+
+  <xsd:element name="set">
     <xsd:annotation>
-      <xsd:documentation>Adds an XML attribute to the parent element tag likethe
-        <code>&lt;xsl:attribute&gt;</code>tag.
-        <authortag>James Strachan</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which defines a variable from an XPath expression.
+        This function creates a variable of type java.util.List or org.dom4j.Node
+        (for example org.dom4j.Element or org.dom4j.Attribute).
+        Thus, the variable created from xml:set can be
+        used from the other xml library functions.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
         <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
-      <xsd:attribute name="name">
+      <xsd:attribute name="var">
         <xsd:annotation>
-          <xsd:documentation>Sets the name of the attribute.</xsd:documentation>
+          <xsd:documentation>Sets the variable name to define for this expression</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
-      <xsd:attribute name="URI">
+      <xsd:attribute name="select">
         <xsd:annotation>
-          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="single">
+        <xsd:annotation>
+          <xsd:documentation>If set to true will only take the first element matching.
+            It then guarantees that the result is of type
+            org.dom4j.Node thereby making sure that, for example,
+            when an element is selected, one can directly call such methods
+            as setAttribute. If set to false, guarantees that a list is returned.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="asString">
+        <xsd:annotation>
+          <xsd:documentation>If set to true, will ensure that the (XPath) text-value
+            of the selected node is taken instead of the node
+            itself.
+            This ensures that, thereafter, string manipulations
+            can be performed on the result.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="delim">
+        <xsd:annotation>
+          <xsd:documentation>
+            If set, returns a string delimited by this delimiter.
+            Implies
+
+            <code>asString</code>
+            to be true.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="sort">
+        <xsd:annotation>
+          <xsd:documentation>Sets the xpath expression to use to sort selected nodes.
+            Ignored if single is true.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="descending">
+        <xsd:annotation>
+          <xsd:documentation>Set whether to sort ascending or descending.</xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="trim">
@@ -439,12 +177,156 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="replaceNamespace">
+    <xsd:annotation>
+      <xsd:documentation>Replace namespace is a filter to change the namespace of any
+        elemement attribute passing through it.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="fromURI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the source namespace URI to replace.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="toURI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the destination namespace URI to replace.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="">
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="parse">
+    <xsd:annotation>
+      <xsd:documentation>A tag which parses some XML and defines a variable with the parsed Document.
+        The XML can either be specified as its body or can be passed in via the
+        xml property which can be a Reader, InputStream, URL or String URI.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="xml">
+        <xsd:annotation>
+          <xsd:documentation>Sets the source of the XML which is either a String URI, a File, Reader or InputStream</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="validate">
+        <xsd:annotation>
+          <xsd:documentation>Sets whether XML validation is enabled or disabled</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="var">
+        <xsd:annotation>
+          <xsd:documentation>Sets the variable name that will be used for the Document variable created</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the text to be parsed by this parser</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SAXReader">
+        <xsd:annotation>
+          <xsd:documentation>Sets the SAXReader used for parsing</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="param">
+    <xsd:annotation>
+      <xsd:documentation>Sets a parameter in the parent transform tag</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value">
+        <xsd:annotation>
+          <xsd:documentation>Sets the value of the attribute</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="if">
+    <xsd:annotation>
+      <xsd:documentation>Evaluates the XPath expression to be a boolean and only evaluates the body
+        if the expression is true.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="forEach">
     <xsd:annotation>
-      <xsd:documentation>A tag which performs an iteration over the results of an XPath expression
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which performs an iteration over the results of an XPath expression</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -482,40 +364,11 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="if">
-    <xsd:annotation>
-      <xsd:documentation>Evaluates the XPath expression to be a boolean and only evaluates the bodyif the expression is true.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType mixed="true">
-      <xsd:sequence>
-        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-      <xsd:attribute name="select">
-        <xsd:annotation>
-          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="trim">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-      <xsd:attribute name="escapeText">
-        <xsd:annotation>
-          <xsd:documentation/>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+
   <xsd:element name="expr">
     <xsd:annotation>
-      <xsd:documentation>A tag which performs a string XPath expression; similar to &lt;xsl:value-of&gt;in XSLT
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which performs a string XPath expression; similar to &lt;xsl:value-of&gt;
+        in XSLT</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -538,12 +391,49 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="element">
+    <xsd:annotation>
+      <xsd:documentation>
+        A tag to produce an XML element which can contain other attributes
+        or elements like the
+
+        <code>&lt;xsl:element&gt;</code>
+        tag.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the qualified name of the element</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="URI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="doctype">
     <xsd:annotation>
-      <xsd:documentation>A tag which outputs a DOCTYPE declaration to the current XML output pipe.Note that there should only be a single DOCTYPE declaration in any XML stream andit should occur before any element content.
-        <authortag>&lt;a href="mailto:jstrachan@apache.org"&gt;James Strachan&lt;/a&gt;</authortag>
-        <versiontag>$Revision: 847 $</versiontag>
-      </xsd:documentation>
+      <xsd:documentation>A tag which outputs a DOCTYPE declaration to the current XML output pipe.
+        Note that there should only be a single DOCTYPE declaration in any XML stream and
+        it should occur before any element content.</xsd:documentation>
     </xsd:annotation>
     <xsd:complexType mixed="true">
       <xsd:sequence>
@@ -576,4 +466,133 @@
       </xsd:attribute>
     </xsd:complexType>
   </xsd:element>
+
+  <xsd:element name="copy">
+    <xsd:annotation>
+      <xsd:documentation>A tag which performs a copy operation like the XSLT tag,
+        performing a shallow copy of the element and its attributes but no content.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lexical">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="copyOf">
+    <xsd:annotation>
+      <xsd:documentation>A tag which performs a copy-of operation like the XSLT tag</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="select">
+        <xsd:annotation>
+          <xsd:documentation>Sets the XPath expression to evaluate.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="lexical">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="comment">
+    <xsd:annotation>
+      <xsd:documentation>A tag which outputs a comment to the underlying XMLOutput based on the
+        contents of its body.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="text">
+        <xsd:annotation>
+          <xsd:documentation>Sets the comment text. If no text is specified then the body of the tag
+            is used instead.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="attribute">
+    <xsd:annotation>
+      <xsd:documentation>
+        Adds an XML attribute to the parent element tag like
+        the
+
+        <code>&lt;xsl:attribute&gt;</code>
+        tag.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence>
+        <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name">
+        <xsd:annotation>
+          <xsd:documentation>Sets the name of the attribute.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="URI">
+        <xsd:annotation>
+          <xsd:documentation>Sets the namespace URI of the element</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="trim">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="escapeText">
+        <xsd:annotation>
+          <xsd:documentation/>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
 </xsd:schema>


### PR DESCRIPTION
These updates have been generated by running `mvn clean org.jvnet.maven-jellydoc-plugin:maven-jellydoc-plugin:1.11:jellydoc` in the jelly and stapler repository. The output aligns with the format we're using there and the binaries produced.

To note, there are more XSDs available in the https://github.com/jenkinsci/jelly/tree/master/jelly-tags folder, but we don't build or distribute these, and they are not maven-ized. Therefore, I didn't include XSD updates for them.

Closes #145 
Fixes #92 