### PR TITLE
Extract logic of detecting a Stapler view into extension point

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ ideaVersion=2021.3
 sinceIdeaVersion=
 # see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type for list of accepted types
 ideaType=IC
-platformPlugins=properties,java
+platformPlugins=properties,java,org.intellij.groovy
 intellijPublishToken=

--- a/src/main/java/io/jenkins/stapler/idea/facets/groovy/GroovyViewPredicate.java
+++ b/src/main/java/io/jenkins/stapler/idea/facets/groovy/GroovyViewPredicate.java
@@ -1,0 +1,12 @@
+package io.jenkins.stapler.idea.facets.groovy;
+
+import com.intellij.psi.PsiFile;
+import org.jetbrains.plugins.groovy.GroovyFileType;
+import org.kohsuke.stapler.idea.extension.JavaStructureViewExtension;
+
+public class GroovyViewPredicate implements JavaStructureViewExtension.StaplerViewPredicate {
+    @Override
+    public boolean test(PsiFile psiFile) {
+        return psiFile.getFileType() == GroovyFileType.GROOVY_FILE_TYPE;
+    }
+}

--- a/src/main/java/io/jenkins/stapler/idea/facets/jelly/JellyViewPredicate.java
+++ b/src/main/java/io/jenkins/stapler/idea/facets/jelly/JellyViewPredicate.java
@@ -1,0 +1,12 @@
+package io.jenkins.stapler.idea.facets.jelly;
+
+import com.intellij.psi.PsiFile;
+import org.kohsuke.stapler.idea.extension.JavaStructureViewExtension;
+import org.kohsuke.stapler.idea.language.JellyFileType;
+
+public class JellyViewPredicate implements JavaStructureViewExtension.StaplerViewPredicate {
+    @Override
+    public boolean test(PsiFile psiFile) {
+        return psiFile.getFileType() == JellyFileType.INSTANCE;
+    }
+}

--- a/src/main/resources/META-INF/jenkins-groovy.xml
+++ b/src/main/resources/META-INF/jenkins-groovy.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="Stapler plugin for IntelliJ IDEA">
+    <staplerViewPredicate implementation="io.jenkins.stapler.idea.facets.groovy.GroovyViewPredicate" />
+  </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,14 @@
 <!--  <version>1.8</version>-->
 <!--  <idea-version since-build="110.00"/>-->
 
+  <extensionPoints>
+    <extensionPoint name="staplerViewPredicate" interface="org.kohsuke.stapler.idea.extension.JavaStructureViewExtension$StaplerViewPredicate"/>
+  </extensionPoints>
+
+  <extensions defaultExtensionNs="Stapler plugin for IntelliJ IDEA">
+    <staplerViewPredicate implementation="io.jenkins.stapler.idea.facets.jelly.JellyViewPredicate" />
+  </extensions>
+
   <extensions defaultExtensionNs="com.intellij">
     <!--
       REFERENCE:
@@ -137,5 +145,6 @@
   <depends>com.intellij.properties</depends>
   <!-- this is needed for language injection -->
   <!--<depends>org.intellij.intelliLang</depends>-->
+  <depends optional="true" config-file="jenkins-groovy.xml">org.intellij.groovy</depends>
 
 </idea-plugin>


### PR DESCRIPTION
* Simple predicated that test the PsiFile to tell if it is one of view types
  * Declared as Extension Point
* Example of optional extension implementation that only enabled when optional Groovy plugin dependency is installed.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

This is more of an example of how to create an Extension Point. Not sure if this functionality needs an extension point exactly.