### PR TITLE
fix(build): remove `clean` task to pass on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
                     stage('Build Plugin') {
                         steps {
                             script {
-                                String command = "gradlew ${gradleOptions.join ' '} clean check assemble"
+                                String command = "gradlew ${gradleOptions.join ' '} check assemble"
                                 if (isUnix()) {
                                     command = "./${command}"
                                 }


### PR DESCRIPTION
This PR removes the `clean` gradle task not needed on ci.jenkins.io ephemeral agents to fix the following Windows builds error:
```
10:22:17  FAILURE: Build failed with an exception.
10:22:17  
10:22:17  * What went wrong:
10:22:17  Execution failed for task ':clean'.
10:22:17  > java.io.IOException: Unable to delete directory 'C:\Jenkins\agent\workspace\ugins_idea-stapler-plugin_PR-160\build'
10:22:17      Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.
10:22:17      - C:\Jenkins\agent\workspace\ugins_idea-stapler-plugin_PR-160\build\tmp\.cache\expanded\expanded.lock
10:22:17      - C:\Jenkins\agent\workspace\ugins_idea-stapler-plugin_PR-160\build\tmp\.cache\expanded
10:22:17      - C:\Jenkins\agent\workspace\ugins_idea-stapler-plugin_PR-160\build\tmp\.cache
10:22:17      - C:\Jenkins\agent\workspace\ugins_idea-stapler-plugin_PR-160\build\tmp
```

Ref: https://github.com/jenkins-infra/helpdesk/issues/3744

### Testing done
Tested via a replay:
- https://ci.jenkins.io/job/Plugins/job/idea-stapler-plugin/job/PR-160/3/console
- https://ci.jenkins.io/job/Plugins/job/idea-stapler-plugin/job/PR-163/2/console
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
