### PR TITLE
Usages of Apache commons-lang2 are removed for IntelliJ compatibility reasons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
         exclude group: "commons-logging", module: "commons-logging"
     }
     implementation 'net.java.dev.textile-j:textile-j:2.2.864'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/src/main/java/org/kohsuke/stapler/idea/GotoViewAction.java
+++ b/src/main/java/org/kohsuke/stapler/idea/GotoViewAction.java
@@ -22,7 +22,7 @@ import com.intellij.psi.PsiJavaFile;
 import com.intellij.psi.PsiPackage;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtilBase;
-import org.apache.commons.lang.ArrayUtils;
+import com.intellij.util.ArrayUtil;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -145,7 +145,7 @@ public class GotoViewAction extends GotoActionBase {
             @Override
             @NotNull
             public String @NotNull [] getSeparators() {
-                return ArrayUtils.EMPTY_STRING_ARRAY;
+                return ArrayUtil.EMPTY_STRING_ARRAY;
             }
 
             @Override

--- a/src/main/java/org/kohsuke/stapler/idea/JellyTagLibReferenceProvider.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JellyTagLibReferenceProvider.java
@@ -17,8 +17,8 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
+import com.intellij.util.ArrayUtil;
 import com.intellij.util.ProcessingContext;
-import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -141,7 +141,7 @@ public class JellyTagLibReferenceProvider extends PsiReferenceProvider {
                 @Override
                 @NotNull
                 public Object @NotNull [] getVariants() {
-                    return ArrayUtils.EMPTY_OBJECT_ARRAY;
+                    return ArrayUtil.EMPTY_OBJECT_ARRAY;
                 }
             });
         }

--- a/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
+++ b/src/main/java/org/kohsuke/stapler/idea/JexlInspection.java
@@ -1,7 +1,5 @@
 package org.kohsuke.stapler.idea;
 
-import java.util.Arrays;
-
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -13,8 +11,10 @@ import com.intellij.psi.xml.XmlElement;
 import com.intellij.psi.xml.XmlText;
 import org.apache.commons.jexl.ExpressionFactory;
 import org.apache.commons.jexl.parser.ParseException;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.kohsuke.stapler.idea.psi.JellyFile;
+
+import java.util.Arrays;
 
 
 /**
@@ -265,7 +265,7 @@ public class JexlInspection extends LocalXmlInspectionTool {
                 // OK
                 return null;
             } else {
-                ExpressionFactory.createExpression(StringEscapeUtils.unescapeHtml(expr));
+                ExpressionFactory.createExpression(StringEscapeUtils.unescapeHtml4(expr));
                 return null;
             }
         } catch (ParseException e) {


### PR DESCRIPTION
According to https://plugins.jetbrains.com/docs/intellij/api-changes-list-2023.html#8c50ccb_40 commons-lang2 and commons-collections libraries are being removed. Usages are replaced with IntelliJ and commons-text alternatives.

Fixes #167 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
