### PR TITLE
Update IntelliJ baseline to 2022

### DIFF
--- a/.run/idea-stapler-plugin [runIde 2023].run.xml
+++ b/.run/idea-stapler-plugin [runIde 2023].run.xml
@@ -1,10 +1,10 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="idea-stapler-plugin [runIde 2022]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="idea-stapler-plugin [runIde 2023]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PideaVersion=2022.2.3" />
+      <option name="scriptParameters" value="-PideaVersion=2023.2.5" />
       <option name="taskDescriptions">
         <list />
       </option>
@@ -18,6 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/idea-stapler-plugin [runIde IU].run.xml
+++ b/.run/idea-stapler-plugin [runIde IU].run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PideaType=IU -PideaVersion=2022.2.3" />
+      <option name="scriptParameters" value="-PideaType=IU -PideaVersion=2023.2.5" />
       <option name="taskDescriptions">
         <list />
       </option>
@@ -18,6 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                                 if (isUnix()) {
                                     command = "./${command}"
                                 }
-                                infra.runWithJava(command, "11", extraEnv)
+                                infra.runWithJava(command, "17", extraEnv)
                             }
                         }
                         post {
@@ -49,7 +49,7 @@ pipeline {
                                 if (isUnix()) {
                                     command = "./" + command
                                 }
-                                infra.runWithJava(command, "11", extraEnv)
+                                infra.runWithJava(command, "17", extraEnv)
                             }
                             archiveArtifacts artifacts: '**/build/reports/pluginVerifier/**', fingerprint: false
                             // Look for presence of compatibility warnings or problems

--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,15 @@ import java.util.stream.Collectors
 
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.15.0'
+    id 'org.jetbrains.intellij' version '1.17.0'
 }
 
 group = "org.kohsuke.stapler.idea"
-version = "3.0.2"
+version = "3.0.3-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -58,10 +58,11 @@ intellij {
 }
 
 patchPluginXml {
-    sinceBuild = "213.00"
+    sinceBuild = "223.00"
     untilBuild = ""
     pluginDescription = extractPluginDescription()
     changeNotes = """
+      <h3>3.0.3-SNAPSHOT</h3>
       <h3>3.0.2</h3>
       <ul>
         <li>✍️ Usages of Apache commons-lang2 are removed for IntelliJ compatibility reasons</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # used for intellij build, see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-version 
-ideaVersion=2021.3
+ideaVersion=2022.3
 # specific property for runPluginVerifier to override during runtime `-PsinceIdeaVersion=2022.1`
 sinceIdeaVersion=
 # see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type for list of accepted types


### PR DESCRIPTION
Implements #174. Just like last year, bump the minimum required version by one year, which corresponds to 2022.3. 2022.2 onward requires Java 17, hence, Java is updated as well. There were a few releases of the JetBrains Gradle plugin since I last touched this, so it was updated as well. Persistent run configs are updated to enable testing on 2023 (one year more than the baseline).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
