### PR TITLE
Report custom tag attributes that are marked deprecated.

### DIFF
--- a/src/main/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspection.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspection.java
@@ -15,7 +15,7 @@ public class DeprecatedStaplerJellyCustomTagAttributeInspection extends LocalIns
             @Override
             public void visitXmlAttribute(@NotNull XmlAttribute attribute) {
                 if (attribute.getDescriptor() instanceof StaplerCustomJellyTagfileXmlAttributeDescriptor descriptor && descriptor.getModel().isDeprecated()) {
-                    holder.registerProblem(attribute, "Attribute is deprecated. Use \"Go to declaration\" to find the recommended solution.");
+                    holder.registerProblem(attribute, String.format("Attribute '%s' is deprecated. Use \"Go to declaration\" to find the recommended solution.", attribute.getName()));
                 }
             }
         };

--- a/src/main/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspection.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspection.java
@@ -1,0 +1,23 @@
+package io.jenkins.stapler.idea.jelly;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.XmlElementVisitor;
+import com.intellij.psi.xml.XmlAttribute;
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.stapler.idea.descriptor.StaplerCustomJellyTagfileXmlAttributeDescriptor;
+
+public class DeprecatedStaplerJellyCustomTagAttributeInspection extends LocalInspectionTool {
+    @Override
+    public @NotNull PsiElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+        return new XmlElementVisitor() {
+            @Override
+            public void visitXmlAttribute(@NotNull XmlAttribute attribute) {
+                if (attribute.getDescriptor() instanceof StaplerCustomJellyTagfileXmlAttributeDescriptor descriptor && descriptor.getModel().isDeprecated()) {
+                    holder.registerProblem(attribute, "Attribute is deprecated. Use \"Go to declaration\" to find the recommended solution.");
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/org/kohsuke/stapler/idea/dom/model/AttributeTag.java
+++ b/src/main/java/org/kohsuke/stapler/idea/dom/model/AttributeTag.java
@@ -31,4 +31,9 @@ public class AttributeTag extends TagWithHtmlContent {
         Optional<String> mayBeUseAttrValue = Optional.ofNullable(tag.getAttribute("use")).map(XmlAttribute::getValue);
         return mayBeUseAttrValue.isPresent() && mayBeUseAttrValue.get().equals("required");
     }
+
+    public boolean isDeprecated() {
+        Optional<String> mayBeUseAttrValue = Optional.ofNullable(tag.getAttribute("deprecated")).map(XmlAttribute::getValue);
+        return mayBeUseAttrValue.isPresent() && mayBeUseAttrValue.get().equals("true");
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,10 @@
                          groupName="Stapler"
                          implementationClass="org.kohsuke.stapler.idea.I18nInspection" />
     -->
+    <localInspection language="Jelly" enabledByDefault="true" level="WARNING"
+                     displayName="Deprecated Jelly Tag library attribute usage"
+                     groupName="Stapler"
+                     implementationClass="io.jenkins.stapler.idea.jelly.DeprecatedStaplerJellyCustomTagAttributeInspection" />
     <!-- jelly file definition parser -->
     <lang.parserDefinition language="Jelly"
                            implementationClass="org.kohsuke.stapler.idea.language.JellyParserDefinition"/>

--- a/src/main/resources/inspectionDescriptions/DeprecatedStaplerJellyCustomTagAttribute.html
+++ b/src/main/resources/inspectionDescriptions/DeprecatedStaplerJellyCustomTagAttribute.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+Reports usages of deprecated tag attributes in Jelly files.
+<p>
+    It only analyzes custom tag libraries (a package of Jelly files with a marker file <code>taglib</code>). For attribute to be recognized and considered deprecated it must be explicitly documented and marked as deprecated. Use "Navigate to definition" to jump to the documentation to find the resolution.
+</p>
+</body>
+</html>

--- a/src/test/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspectionTest.java
+++ b/src/test/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspectionTest.java
@@ -24,6 +24,6 @@ public class DeprecatedStaplerJellyCustomTagAttributeInspectionTest extends Base
 
         List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WARNING);
         assertNotEmpty(highlightInfos);
-        assertEquals("Attribute is deprecated. Use \"Go to declaration\" to find the recommended solution.", highlightInfos.get(0).getDescription());
+        assertEquals("Attribute 'title' is deprecated. Use \"Go to declaration\" to find the recommended solution.", highlightInfos.get(0).getDescription());
     }
 }

--- a/src/test/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspectionTest.java
+++ b/src/test/java/io/jenkins/stapler/idea/jelly/DeprecatedStaplerJellyCustomTagAttributeInspectionTest.java
@@ -1,0 +1,29 @@
+package io.jenkins.stapler.idea.jelly;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.util.List;
+
+public class DeprecatedStaplerJellyCustomTagAttributeInspectionTest extends BasePlatformTestCase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        myFixture.enableInspections(new DeprecatedStaplerJellyCustomTagAttributeInspection());
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/testData";
+    }
+
+    public void testDeprecateTagAttribute() {
+        myFixture.copyDirectoryToProject("testlib", "testlib");
+        myFixture.configureByFile(getTestName(true) + ".jelly");
+
+        List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WARNING);
+        assertNotEmpty(highlightInfos);
+        assertEquals("Attribute is deprecated. Use \"Go to declaration\" to find the recommended solution.", highlightInfos.get(0).getDescription());
+    }
+}

--- a/src/test/testData/deprecateTagAttribute.jelly
+++ b/src/test/testData/deprecateTagAttribute.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/testlib">
+    <t:test title="Hello, World!" />
+</j:jelly>

--- a/src/test/testData/testlib/test.jellytag
+++ b/src/test/testData/testlib/test.jellytag
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    <st:documentation>
+        <st:attribute name="title" deprecated="true">title, deprecated use tooltip instead, or htmlTooltip if you intend to pass HTML.</st:attribute>
+    </st:documentation>
+    <p>Test</p>
+</j:jelly>


### PR DESCRIPTION
Fixes #172 by adding inspection for deprecated tags.

An inspection checks if the attribute of the custom tag is documented as deprecated and annotates it appropriately: "Attribute is deprecated. Use \"Go to declaration\" to find the recommended solution."

### Testing done

Created a Hello World plugin and used deprecated `title` attribute of `l:icon`:

<img width="732" alt="Screenshot 2024-01-30 at 11 29 06 pm" src="https://github.com/jenkinsci/idea-stapler-plugin/assets/348580/f6536cad-1510-41d6-bcee-059e0a7bb9cf">

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
