### PR TITLE
Suggest symbols in "icon" attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.kohsuke.stapler.idea"
-version = "3.0.6"
+version = "3.0.7"
 
 java {
     toolchain {
@@ -91,6 +91,10 @@ patchPluginXml {
         <p>For more features see the <a href="https://github.com/jenkinsci/idea-stapler-plugin">documentation</a>.</p>
     """
     changeNotes = """
+      <h3>3.0.7</h3>
+      <ul>
+        <li>🚀 Jenkins Symbols suggestions are now available in "icon" attributes/li>
+      </ul>
       <h3>3.0.6</h3>
       <ul>
         <li>🚀 Jenkins Symbols suggestions are now available when using the icon component</li>

--- a/src/main/java/io/jenkins/stapler/idea/jelly/IconSrcCompletionContributor.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/IconSrcCompletionContributor.java
@@ -63,7 +63,7 @@ public class IconSrcCompletionContributor extends CompletionContributor {
                 if (parent instanceof XmlTag xmlTag) {
                     return "icon".equals(xmlTag.getLocalName()) && "/lib/layout".equals(xmlTag.getNamespace());
                 }
-            }
+            } else return "icon".equals(attribute.getName());
         }
         return false;
     }

--- a/src/main/java/io/jenkins/stapler/idea/jelly/InvalidIconSrcInspection.java
+++ b/src/main/java/io/jenkins/stapler/idea/jelly/InvalidIconSrcInspection.java
@@ -66,19 +66,24 @@ public class InvalidIconSrcInspection extends LocalInspectionTool {
     }
 
     private boolean validAttributeToScan(@NotNull XmlAttribute attribute) {
-        if ("src".equals(attribute.getName())) {
+        String attributeName = attribute.getName();
+        String attributeValue = attribute.getValue();
+
+        // Ignore values that aren't symbols and ignore cases where symbols are dynamically generated
+        if (attributeValue == null || !attributeValue.startsWith("symbol-") || attributeValue.contains("${")) {
+            return false;
+        }
+
+        // If "src" is inside <l:icon>, allow it
+        if ("src".equals(attributeName)) {
             PsiElement parent = attribute.getParent();
             if (parent instanceof XmlTag xmlTag) {
-                String attributeValue = attribute.getValue();
-                if (attributeValue == null) {
-                    return false;
-                }
-                return "icon".equals(xmlTag.getLocalName())
-                        && "/lib/layout".equals(xmlTag.getNamespace())
-                        && attribute.getValue().startsWith("symbol-")
-                        && !attribute.getValue().contains("${"); // In some cases symbols are dynamically generated
+                return "icon".equals(xmlTag.getLocalName()) && "/lib/layout".equals(xmlTag.getNamespace());
             }
+            return false;
         }
-        return false;
+
+        // "icon" is allowed anywhere, as long as it meets the value conditions
+        return "icon".equals(attributeName);
     }
 }

--- a/src/test/java/io/jenkins/stapler/idea/jelly/IconSrcCompletionContributorTest.java
+++ b/src/test/java/io/jenkins/stapler/idea/jelly/IconSrcCompletionContributorTest.java
@@ -4,15 +4,27 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 
 public class IconSrcCompletionContributorTest extends BasePlatformTestCase {
 
-    public void testDefaultTagLibrary() {
+    public void testDefaultTagLibrary_srcAttribute() {
         assertDefaultTagLibrary(
                 """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <?jelly escape-by-default='true'?>
-                <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-                    <l:icon src="symbol-<caret>
-                </j:jelly>
-                """,
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?jelly escape-by-default='true'?>
+            <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+                <l:icon src="symbol-<caret>
+            </j:jelly>
+            """,
+                111);
+    }
+
+    public void testDefaultTagLibrary_iconAttribute() {
+        assertDefaultTagLibrary(
+                """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?jelly escape-by-default='true'?>
+            <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+                <l:notice icon="symbol-<caret>
+            </j:jelly>
+            """,
                 111);
     }
 

--- a/src/test/java/io/jenkins/stapler/idea/jelly/InvalidIconSrcTest.java
+++ b/src/test/java/io/jenkins/stapler/idea/jelly/InvalidIconSrcTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.stapler.idea.jelly;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import java.util.List;
+
+public class InvalidIconSrcTest extends BasePlatformTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        myFixture.enableInspections(new InvalidIconSrcInspection());
+    }
+
+    public void testInvalidIconAttribute_srcAttribute() {
+        createFile(
+                """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?jelly escape-by-default='true'?>
+            <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+                <l:icon src="symbol-invalid" />
+            </j:jelly>
+            """);
+
+        List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WARNING);
+        assertEquals(
+                "'symbol-invalid' isn't a valid symbol", highlightInfos.get(1).getDescription());
+    }
+
+    public void testInvalidIconAttribute_iconAttribute() {
+        createFile(
+                """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?jelly escape-by-default='true'?>
+            <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+                <l:notice icon="symbol-invalid" />
+            </j:jelly>
+            """);
+
+        List<HighlightInfo> highlightInfos = myFixture.doHighlighting(HighlightSeverity.WARNING);
+        assertEquals(
+                "'symbol-invalid' isn't a valid symbol", highlightInfos.get(1).getDescription());
+    }
+
+    private void createFile(String body) {
+        myFixture.configureByText("basic.jelly", body);
+    }
+}


### PR DESCRIPTION
Previously _only_ the `<l:icon />` component supports autocompletion for Symbols, this PR updates fixes that so that components with `icon` attributes now support autocompletion too.

### Testing done

* Still works for `src` attribute on `<l:icon />`
* Works for `icon` attributes
* Added additional tests

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
